### PR TITLE
ci: include license files in packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,13 +181,11 @@ if(UNIX AND NOT APPLE)
 	set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES PREFIX "")
 	target_link_libraries(${CMAKE_PROJECT_NAME} obs-frontend-api)
 
-	file(GLOB locale_files data/locale/*.ini)
-
 	install(TARGETS ${CMAKE_PROJECT_NAME}
 		LIBRARY DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/obs-plugins")
 
-	install(FILES ${locale_files}
-		DESTINATION "${CMAKE_INSTALL_FULL_DATAROOTDIR}/obs/obs-plugins/${CMAKE_PROJECT_NAME}/locale")
+	install(DIRECTORY data/
+		DESTINATION "${CMAKE_INSTALL_FULL_DATAROOTDIR}/obs/obs-plugins/${CMAKE_PROJECT_NAME}")
 endif()
 # --- End of section ---
 

--- a/ci/linux/build-ubuntu.sh
+++ b/ci/linux/build-ubuntu.sh
@@ -8,6 +8,9 @@ patch -p1 < ../ci/common/dlib-slim.patch
 patch -p1 < ../ci/common/dlib-cmake-no-openblasp.patch
 cd ..
 
+cp LICENSE data/LICENSE-plugin
+cp dlib/LICENSE.txt data/LICENSE-dlib
+
 mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=/usr ..
 make -j4

--- a/ci/macos/package-macos.sh
+++ b/ci/macos/package-macos.sh
@@ -75,6 +75,8 @@ ziproot=package-zip/$PLUGIN_NAME
 zipfile=${PLUGIN_NAME}-${GIT_HASH}-macos.zip
 mkdir -p $ziproot/bin
 cp ./build/$PLUGIN_NAME.so $ziproot/bin/
+cp LICENSE data/LICENSE-$PLUGIN_NAME
+cp dlib/LICENSE.txt data/LICENSE-dlib
 cp -a data $ziproot/
 mkdir -p ./release
 mv lib $ziproot/

--- a/ci/windows/package-windows.cmd
+++ b/ci/windows/package-windows.cmd
@@ -7,6 +7,9 @@ git rev-parse --short HEAD > package-version.txt
 set /p PackageVersion=<package-version.txt
 del package-version.txt
 
+copy ..\LICENSE          ..\release\data\obs-plugins\%PluginName%\LICENCE-%PluginName%.txt
+copy ..\dlib\LICENSE.txt ..\release\data\obs-plugins\%PluginName%\LICENSE-dlib.txt
+
 REM Package ZIP archive
 7z a "%PluginName%-%PackageVersion%-Windows.zip" "..\release\*"
 


### PR DESCRIPTION
Binary packages should include license files for dlib.