### PR TITLE
Linux macOS: Increase priority for face tracker

### DIFF
--- a/src/face-tracker-base.cpp
+++ b/src/face-tracker-base.cpp
@@ -28,7 +28,7 @@ void *face_tracker_base::thread_routine(void *p)
 {
 	face_tracker_base *base = (face_tracker_base*)p;
 #ifndef _WIN32
-	setpriority(PRIO_PROCESS, 0, 19);
+	setpriority(PRIO_PROCESS, 0, 17);
 #else // _WIN32
 	SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_LOWEST);
 #endif // _WIN32


### PR DESCRIPTION
Previously tracker and detector have the same priority.
The tracker is expected to calculate earlier to achieve
smooth tracking. Hence, the priority is a little increased.
Since Windows provides grain like Linux and macOS, there is
no change for Windows.