### PR TITLE
Include cmath instead of math.h

### DIFF
--- a/src/face-tracker.cpp
+++ b/src/face-tracker.cpp
@@ -8,7 +8,7 @@
 #include "face-tracker-dlib.h"
 #include <algorithm>
 #include <deque>
-#include <math.h>
+#include <cmath>
 #include <graphics/matrix4.h>
 
 // #define debug_track(fmt, ...) blog(LOG_INFO, fmt, __VA_ARGS__)


### PR DESCRIPTION
On Mac OS X 10.11, `std::abs` is not available from `math.h`.