### PR TITLE
ci(linux): Fix libdir for Ubuntu

### DIFF
--- a/ci/linux/build-ubuntu.sh
+++ b/ci/linux/build-ubuntu.sh
@@ -11,6 +11,8 @@ cd ..
 cp LICENSE data/LICENSE-plugin
 cp dlib/LICENSE.txt data/LICENSE-dlib
 
+sed -i 's;${CMAKE_INSTALL_FULL_LIBDIR};/usr/lib;' CMakeLists.txt
+
 mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=/usr ..
 make -j4


### PR DESCRIPTION
Plugin .so file should be placed under `/usr/lib/obs-plugins/`.
There are same issue on my other plugins.
Fixes #22