### PR TITLE
Configurable frame scale for detection and tracking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ set(PLUGIN_SOURCES
 	src/face-detector-dlib.cpp
 	src/face-tracker-base.cpp
 	src/face-tracker-dlib.cpp
+	src/texture-object.cpp
 )
 
 set(PLUGIN_HEADERS
@@ -61,6 +62,7 @@ set(PLUGIN_HEADERS
 	src/face-detector-dlib.h
 	src/face-tracker-base.h
 	src/face-tracker-dlib.h
+	src/texture-object.h
 )
 
 # --- Platform-independent build settings ---

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,8 +41,6 @@ jobs:
       displayName: Restore cached OBS Studio dependencies
       inputs:
         key: 'obsdeps | "$(Agent.OS)"'
-        restoreKeys: |
-          obsdeps | "$(Agent.OS)"
         path: $(DepsBasePath)
 
     - script: ./ci/windows/download-obs-deps.cmd
@@ -52,8 +50,6 @@ jobs:
       displayName: Restore cached OBS Studio builds
       inputs:
         key: 'obs "$(OBSLatestTag)" | "$(Agent.OS)"'
-        restoreKeys: |
-          obs | "$(Agent.OS)"
         path: $(OBSPath)
 
     - script: ./ci/windows/prepare-obs-windows.cmd

--- a/data/face-tracker.effect
+++ b/data/face-tracker.effect
@@ -1,0 +1,37 @@
+uniform float4x4 ViewProj;
+uniform texture2d image;
+
+sampler_state def_sampler {
+	Filter   = Linear;
+	AddressU = Clamp;
+	AddressV = Clamp;
+};
+
+struct VertInOut {
+	float4 pos : POSITION;
+	float2 uv  : TEXCOORD0;
+};
+
+VertInOut VSDefault(VertInOut vert_in)
+{
+	VertInOut vert_out;
+	vert_out.pos = mul(float4(vert_in.pos.xyz, 1.0), ViewProj);
+	vert_out.uv  = vert_in.uv;
+	return vert_out;
+}
+
+float4 PS_RGB2Y(VertInOut vert_in) : TARGET
+{
+	float4 rgb = image.Sample(def_sampler, vert_in.uv);
+	float y = 0.299 * rgb.x + 0.587 * rgb.y + 0.114 * rgb.z;
+	return float4(y, 0.0, 0.0, 1.0);
+}
+
+technique DrawY
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PS_RGB2Y(vert_in);
+	}
+}

--- a/doc/properties.md
+++ b/doc/properties.md
@@ -24,12 +24,18 @@ If you want to save only tracking parameters (`Upsize recognized face` and `Trac
 ### Save and load control parameters
 If you want to save only contol parameters (`Tracking response`), enable only this check-box.
 
-## Upsize recognized face
+## Face detection options
 
 ### Left, right, top, bottom
 These properties upsize (or downsize) the recognized face by multiple of the width or height.
 
 The motivation is that the face recognition returns a rectangle that is smaller than the actual face.
+
+### Scale image
+The frame will be scaled before sending into face detection and tracking algorithm.
+Default is `2`.
+Larger value will reduce CPU usage but too large value will fail to detect faces.
+The face detection engine requires size of the faces at least 80x80.
 
 ## Tracking target location
 

--- a/src/face-detector-base.h
+++ b/src/face-detector-base.h
@@ -33,7 +33,7 @@ class face_detector_base
 		int unlock() { return pthread_mutex_unlock(&mutex); }
 		int signal() { return pthread_cond_signal(&cond); }
 
-		virtual void set_texture(uint8_t *data, uint32_t linesize, uint32_t width, uint32_t height) = 0;
+		virtual void set_texture(class texture_object *) = 0;
 		virtual void get_faces(std::vector<struct rect_s> &) = 0;
 
 		void start();

--- a/src/face-detector-dlib.h
+++ b/src/face-detector-dlib.h
@@ -12,6 +12,6 @@ class face_detector_dlib : public face_detector_base
 	public:
 		face_detector_dlib();
 		virtual ~face_detector_dlib();
-		virtual void set_texture(uint8_t *data, uint32_t linesize, uint32_t width, uint32_t height);
+		void set_texture(class texture_object *) override;
 		virtual void get_faces(std::vector<struct rect_s> &);
 };

--- a/src/face-tracker-base.h
+++ b/src/face-tracker-base.h
@@ -27,9 +27,9 @@ class face_tracker_base
 		int unlock() { return pthread_mutex_unlock(&mutex); }
 		int signal() { return pthread_cond_signal(&cond); }
 
-		virtual void set_texture(uint8_t *data, uint32_t linesize, uint32_t width, uint32_t height) = 0;
+		virtual void set_texture(class texture_object *) = 0;
 		virtual void set_position(const rect_s &rect) = 0;
-		virtual void get_face(struct rect_s &) = 0;
+		virtual bool get_face(struct rect_s &) = 0;
 
 		void start();
 		void stop();

--- a/src/face-tracker-dlib.cpp
+++ b/src/face-tracker-dlib.cpp
@@ -2,26 +2,29 @@
 #include <util/platform.h>
 #include <util/threading.h>
 #include "plugin-macros.generated.h"
+#include "texture-object.h"
 #include "face-tracker-dlib.h"
 
 #include <dlib/image_processing/scan_fhog_pyramid.h>
 #include <dlib/image_processing/correlation_tracker.h>
 
-#define SCALE 2
-
 struct face_tracker_dlib_private_s
 {
-	dlib::array2d<unsigned char> img;
+	texture_object *tex;
 	rect_s rect;
 	dlib::correlation_tracker *tracker;
 	float score0;
 	float pslr_max, pslr_min;
 	bool need_restart;
 	uint64_t last_ns;
+	float scale_orig;
+	int n_track;
 	face_tracker_dlib_private_s()
 	{
 		tracker = NULL;
 		need_restart = false;
+		tex = NULL;
+		rect.score = 0.0f;
 	}
 };
 
@@ -36,57 +39,71 @@ face_tracker_dlib::~face_tracker_dlib()
 	delete p;
 }
 
-void face_tracker_dlib::set_texture(uint8_t *data, uint32_t linesize, uint32_t width, uint32_t height)
+void face_tracker_dlib::set_texture(class texture_object *tex)
 {
-	p->img.set_size(height/SCALE, width/SCALE);
-	for (int i=0; i<height/SCALE; i++) {
-		auto row = p->img[i];
-		uint8_t *line = data+(i*SCALE)*linesize;
-		for (int j=0; j<width/SCALE; j++) {
-			int r = line[j*SCALE*4+0];
-			int g = line[j*SCALE*4+1];
-			int b = line[j*SCALE*4+2];
-			row[j] = (+306*r +601*g +117*b)/1024; // BT.601
-		}
-	}
+	if (p->tex) p->tex->release();
+	tex->addref();
+	p->tex = tex;
+	p->n_track = 0;
 }
 
 void face_tracker_dlib::set_position(const rect_s &rect)
 {
-	p->rect = rect;
+	p->rect.x0 = rect.x0 / p->tex->scale;
+	p->rect.y0 = rect.y0 / p->tex->scale;
+	p->rect.x1 = rect.x1 / p->tex->scale;
+	p->rect.y1 = rect.y1 / p->tex->scale;
+	p->rect.score = 1.0f;
 	p->need_restart = true;
+	p->n_track = 0;
 }
 
 void face_tracker_dlib::track_main()
 {
+	if (!p->tex)
+		return;
+
 	uint64_t ns = os_gettime_ns();
 	if (p->need_restart) {
 		if (!p->tracker)
 			p->tracker = new dlib::correlation_tracker();
 
-		dlib::rectangle r (p->rect.x0/SCALE, p->rect.y0/SCALE, p->rect.x1/SCALE, p->rect.y1/SCALE);
-		p->tracker->start_track(p->img, r);
+		dlib::rectangle r (p->rect.x0, p->rect.y0, p->rect.x1, p->rect.y1);
+		p->tracker->start_track(p->tex->get_dlib_img(), r);
 		p->score0 = p->rect.score;
 		p->need_restart = false;
 		p->pslr_max = 0.0f;
 		p->pslr_min = 1e9f;
+		p->scale_orig = p->tex->scale;
+	}
+	else if (p->tex->scale != p->scale_orig) {
+		p->rect.score = 0.0f;
 	}
 	else {
-		float s = p->tracker->update(p->img);
+		float s = p->tracker->update(p->tex->get_dlib_img());
 		if (s>p->pslr_max) p->pslr_max = s;
 		if (s<p->pslr_min) p->pslr_min = s;
 		dlib::rectangle r = p->tracker->get_position();
-		p->rect.x0 = r.left() * SCALE;
-		p->rect.y0 = r.top() * SCALE;
-		p->rect.x1 = r.right() * SCALE;
-		p->rect.y1 = r.bottom() * SCALE;
+		p->rect.x0 = r.left() * p->tex->scale;
+		p->rect.y0 = r.top() * p->tex->scale;
+		p->rect.x1 = r.right() * p->tex->scale;
+		p->rect.y1 = r.bottom() * p->tex->scale;
 		s = p->pslr_max / p->pslr_min * ((ns-p->last_ns)*1e-9f);
 		p->rect.score = (p->rect.score /*+ 0.0f*s */) / (1.0f + s);
+		p->n_track += 1;
 	}
 	p->last_ns = ns;
+
+	if (p->tex) p->tex->release();
+	p->tex = NULL;
 }
 
-void face_tracker_dlib::get_face(struct rect_s &rect)
+bool face_tracker_dlib::get_face(struct rect_s &rect)
 {
-	rect = p->rect;
+	if (p->n_track>0) {
+		rect = p->rect;
+		return true;
+	}
+	else
+		return false;
 }

--- a/src/face-tracker-dlib.h
+++ b/src/face-tracker-dlib.h
@@ -13,7 +13,7 @@ class face_tracker_dlib : public face_tracker_base
 		face_tracker_dlib();
 		virtual ~face_tracker_dlib();
 
-		virtual void set_texture(uint8_t *data, uint32_t linesize, uint32_t width, uint32_t height);
+		void set_texture(texture_object *) override;
 		virtual void set_position(const rect_s &rect);
-		virtual void get_face(struct rect_s &);
+		virtual bool get_face(struct rect_s &);
 };

--- a/src/face-tracker.cpp
+++ b/src/face-tracker.cpp
@@ -1,20 +1,23 @@
 #include <obs-module.h>
-#include <graphics/vec2.h>
-#include <graphics/graphics.h>
 #include <util/platform.h>
 #include <util/threading.h>
+#include <graphics/vec2.h>
+#include <graphics/graphics.h>
 #include "plugin-macros.generated.h"
 #include "face-detector-base.h"
 #include "face-detector-dlib.h"
 #include "face-tracker-base.h"
 #include "face-tracker-dlib.h"
+#include "texture-object.h"
 #include <algorithm>
 #include <deque>
 #include <cmath>
 #include <graphics/matrix4.h>
 
 // #define debug_track(fmt, ...) blog(LOG_INFO, fmt, __VA_ARGS__)
+// #define debug_detect(fmt, ...) blog(LOG_INFO, fmt, __VA_ARGS__)
 #define debug_track(fmt, ...)
+#define debug_detect(fmt, ...)
 
 struct rectf_s
 {
@@ -84,7 +87,9 @@ struct face_tracker_filter
 {
 	obs_source_t *context;
 	gs_texrender_t *texrender;
-	gs_stagesurf_t* stagesurface;
+	gs_texrender_t *texrender_scaled;
+	gs_stagesurf_t *stagesurface;
+	texture_object *cvtex;
 	uint32_t known_width;
 	uint32_t known_height;
 	uint32_t width_with_aspect;
@@ -93,7 +98,6 @@ struct face_tracker_filter
 	int next_tick_stage_to_detector;
 	bool target_valid;
 	bool rendered;
-	bool staged;
 	bool is_active;
 	bool detector_in_progress;
 
@@ -111,6 +115,7 @@ struct face_tracker_filter
 	float upsize_l, upsize_r, upsize_t, upsize_b;
 	float track_z, track_x, track_y;
 	float scale_max;
+	volatile float scale;
 
 	float kp;
 	float ki;
@@ -150,6 +155,7 @@ static void ftf_update(void *data, obs_data_t *settings)
 	s->upsize_r = obs_data_get_double(settings, "upsize_r");
 	s->upsize_t = obs_data_get_double(settings, "upsize_t");
 	s->upsize_b = obs_data_get_double(settings, "upsize_b");
+	s->scale = obs_data_get_double(settings, "scale");
 	s->track_z = obs_data_get_double(settings, "track_z");
 	s->track_x = obs_data_get_double(settings, "track_x");
 	s->track_y = obs_data_get_double(settings, "track_y");
@@ -185,6 +191,7 @@ static void *ftf_create(obs_data_t *settings, obs_source_t *context)
 	s->detect->start();
 	s->trackers = new std::deque<struct tracker_inst_s>;
 	s->trackers_idlepool = new std::deque<struct tracker_inst_s>;
+	s->scale = 2.0f;
 
 	obs_source_update(context, settings);
 	return s;
@@ -197,6 +204,8 @@ static void ftf_destroy(void *data)
 	obs_enter_graphics();
 	gs_texrender_destroy(s->texrender);
 	s->texrender = NULL;
+	gs_texrender_destroy(s->texrender_scaled);
+	s->texrender_scaled = NULL;
 	gs_stagesurface_destroy(s->stagesurface);
 	s->stagesurface = NULL;
 	obs_leave_graphics();
@@ -454,7 +463,8 @@ static obs_properties_t *ftf_properties(void *data)
 		obs_properties_add_float(pp, "upsize_r", obs_module_text("Right"), -0.4, 4.0, 0.2);
 		obs_properties_add_float(pp, "upsize_t", obs_module_text("Top"), -0.4, 4.0, 0.2);
 		obs_properties_add_float(pp, "upsize_b", obs_module_text("Bottom"), -0.4, 4.0, 0.2);
-		obs_properties_add_group(props, "upsize", obs_module_text("Upsize recognized face"), OBS_GROUP_NORMAL, pp);
+		obs_properties_add_float(pp, "scale", obs_module_text("Scale image"), 1.0, 16.0, 1.0);
+		obs_properties_add_group(props, "upsize", obs_module_text("Face detection options"), OBS_GROUP_NORMAL, pp);
 	}
 
 	{
@@ -515,6 +525,7 @@ static void ftf_get_defaults(obs_data_t *settings)
 	obs_data_set_default_double(settings, "upsize_r", 0.2);
 	obs_data_set_default_double(settings, "upsize_t", 0.3);
 	obs_data_set_default_double(settings, "upsize_b", 0.1);
+	obs_data_set_default_double(settings, "scale", 2.0);
 	obs_data_set_default_double(settings, "track_z",  0.70); //  1.00  0.50  0.35
 	obs_data_set_default_double(settings, "track_y", +0.00); // +0.00 +0.10 +0.30
 	obs_data_set_default_double(settings, "scale_max", 10.0);
@@ -717,7 +728,7 @@ static inline void render_target(struct face_tracker_filter *s, obs_source_t *ta
 
 	gs_blend_state_pop();
 
-	s->staged = false;
+	if (s->cvtex) s->cvtex->release(); s->cvtex=NULL;
 }
 
 static inline f3 ensure_range(f3 u, const struct face_tracker_filter *s)
@@ -759,8 +770,8 @@ static inline void calculate_error(struct face_tracker_filter *s)
 		f3 w (trackers[i].crop_rect);
 		float score = trackers[i].rect.score * trackers[i].att;
 		f3 e = (r-w) * score;
-		debug_track("calculate_error: i=%d e={%f %f %f} score=%f", i, e.v[0], e.v[1], e.v[2], score);
-		if (score>0 && !isnan(e)) {
+		debug_track("calculate_error: %d %f %f %f %f", i, e.v[0], e.v[1], e.v[2], score);
+		if (score>0.0f && !isnan(e)) {
 			e_tot += e;
 			sc_tot += score;
 			found = true;
@@ -867,17 +878,40 @@ static inline void copy_detector_to_tracker(struct face_tracker_filter *s)
 	t.state = tracker_inst_s::tracker_state_constructing;
 }
 
-static inline int stage_to_surface(struct face_tracker_filter *s)
-{
-	if (s->staged)
-		return 0;
+static inline void draw_sprite_crop(float width, float height, float x0, float y0, float x1, float y1);
 
-	uint32_t width = s->known_width;
-	uint32_t height = s->known_height;
+static inline void scale_texture(struct face_tracker_filter *s, float scale)
+{
+	if (!s->texrender_scaled)
+		s->texrender_scaled = gs_texrender_create(/*GS_R8*/GS_RGBA, GS_ZS_NONE);
+	const uint32_t cx = s->known_width / scale, cy = s->known_height / scale;
+	gs_texrender_reset(s->texrender_scaled);
+	gs_blend_state_push();
+	gs_blend_function(GS_BLEND_ONE, GS_BLEND_ZERO);
+	if (gs_texrender_begin(s->texrender_scaled, cx, cy)) {
+		// TODO: use custom effect to convert to monochrome
+		gs_ortho(0.0f, (float)cx, 0.0f, (float)cy, -100.0f, 100.0f);
+		gs_effect_t *effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);
+		gs_texture_t *tex = gs_texrender_get_texture(s->texrender);
+		if (tex) {
+			gs_eparam_t *image = gs_effect_get_param_by_name(effect, "image");
+			gs_effect_set_texture(image, tex);
+			while (gs_effect_loop(effect, "Draw"))
+				draw_sprite_crop(cx, cy, 0, 0, 1, 1);
+		}
+		gs_texrender_end(s->texrender_scaled);
+	}
+	gs_blend_state_pop();
+}
+
+static inline int stage_to_surface(struct face_tracker_filter *s, float scale)
+{
+	uint32_t width = s->known_width / scale;
+	uint32_t height = s->known_height / scale;
 	if (width<=0 || height<=0)
 		return 1;
 
-	gs_texture_t *tex = gs_texrender_get_texture(s->texrender);
+	gs_texture_t *tex = gs_texrender_get_texture(s->texrender_scaled);
 	if (!tex)
 		return 2;
 
@@ -890,9 +924,38 @@ static inline int stage_to_surface(struct face_tracker_filter *s)
 
 	gs_stage_texture(s->stagesurface, tex);
 
-	s->staged = true;
-
 	return 0;
+}
+
+static inline void surface_to_cvtex(struct face_tracker_filter *s, float scale)
+{
+	uint8_t *video_data = NULL;
+	uint32_t video_linesize;
+	if (gs_stagesurface_map(s->stagesurface, &video_data, &video_linesize)) {
+		uint32_t width = gs_stagesurface_get_width(s->stagesurface);
+		uint32_t height = gs_stagesurface_get_height(s->stagesurface);
+
+		if (s->cvtex) s->cvtex->release();
+		s->cvtex = new texture_object();
+		s->cvtex->tick = s->tick_cnt;
+		s->cvtex->scale = scale;
+		s->cvtex->set_texture(video_data, video_linesize, width, height);
+
+		gs_stagesurface_unmap(s->stagesurface);
+	}
+}
+
+inline texture_object *get_cvtex(struct face_tracker_filter *s)
+{
+	if (s->cvtex)
+		return s->cvtex;
+	float scale = s->scale;
+	if (scale<1.0f) scale = 1.0f;
+	scale_texture(s, scale);
+	if (stage_to_surface(s, scale))
+		return NULL;
+	surface_to_cvtex(s, scale);
+	return s->cvtex;
 }
 
 static inline void stage_to_detector(struct face_tracker_filter *s)
@@ -903,6 +966,10 @@ static inline void stage_to_detector(struct face_tracker_filter *s)
 	// get previous results
 	if (s->detector_in_progress) {
 		s->detect->get_faces(*s->rects);
+		std::vector<rect_s> &rects = *s->rects;
+		for (int i=0; i<rects.size(); i++)
+			debug_detect("stage_to_detector: rects %d %d %d %d %d %f", i,
+					rects[i].x0, rects[i].y0, rects[i].x1, rects[i].y1, rects[i].score );
 		attenuate_tracker(s);
 		copy_detector_to_tracker(s);
 		s->detector_in_progress = false;
@@ -914,32 +981,25 @@ static inline void stage_to_detector(struct face_tracker_filter *s)
 		return;
 	}
 
-	if (!stage_to_surface(s)) {
-		uint8_t *video_data = NULL;
-		uint32_t video_linesize;
-		if (gs_stagesurface_map(s->stagesurface, &video_data, &video_linesize)) {
-			uint32_t width = s->known_width;
-			uint32_t height = s->known_height;
-			s->detect->set_texture(video_data, video_linesize, width, height);
-			gs_stagesurface_unmap(s->stagesurface);
-			s->detect->signal();
-			s->detector_in_progress = true;
-			s->detect_tick = s->tick_cnt;
+	if (get_cvtex(s)) {
+		s->detect->set_texture(s->cvtex);
+		s->detect->signal();
+		s->detector_in_progress = true;
+		s->detect_tick = s->tick_cnt;
 
-			struct tracker_inst_s t;
-			if (s->trackers_idlepool->size() > 0) {
-				t.tracker = (*s->trackers_idlepool)[0].tracker;
-				(*s->trackers_idlepool)[0].tracker = NULL;
-				s->trackers_idlepool->pop_front();
-			}
-			else
-				t.tracker = new face_tracker_dlib();
-			t.crop_tracker = s->crop_cur;
-			t.state = tracker_inst_s::tracker_state_e::tracker_state_reset_texture;
-			t.tick_cnt = s->tick_cnt;
-			t.tracker->set_texture(video_data, video_linesize, width, height); // TODO: common texture object.
-			s->trackers->push_back(t);
+		struct tracker_inst_s t;
+		if (s->trackers_idlepool->size() > 0) {
+			t.tracker = (*s->trackers_idlepool)[0].tracker;
+			(*s->trackers_idlepool)[0].tracker = NULL;
+			s->trackers_idlepool->pop_front();
 		}
+		else
+			t.tracker = new face_tracker_dlib();
+		t.crop_tracker = s->crop_cur;
+		t.state = tracker_inst_s::tracker_state_e::tracker_state_reset_texture;
+		t.tick_cnt = s->tick_cnt;
+		t.tracker->set_texture(s->cvtex);
+		s->trackers->push_back(t);
 	}
 
 	s->detect->unlock();
@@ -947,17 +1007,9 @@ static inline void stage_to_detector(struct face_tracker_filter *s)
 
 static inline int stage_surface_to_tracker(struct face_tracker_filter *s, struct tracker_inst_s &t)
 {
-	if (int ret = stage_to_surface(s))
-		return ret;
-
-	uint8_t *video_data = NULL;
-	uint32_t video_linesize;
-	if (gs_stagesurface_map(s->stagesurface, &video_data, &video_linesize)) {
-		uint32_t width = s->known_width;
-		uint32_t height = s->known_height;
-		t.tracker->set_texture(video_data, video_linesize, width, height);
+	if (get_cvtex(s)) {
+		t.tracker->set_texture(s->cvtex);
 		t.crop_tracker = s->crop_cur;
-		gs_stagesurface_unmap(s->stagesurface);
 		t.tracker->signal();
 	}
 	else
@@ -982,21 +1034,22 @@ static inline void stage_to_trackers(struct face_tracker_filter *s)
 		}
 		else if (t.state == tracker_inst_s::tracker_state_first_track) {
 			if (!t.tracker->trylock()) {
-				t.tracker->get_face(t.rect);
+				bool ret = t.tracker->get_face(t.rect);
 				t.crop_rect = t.crop_tracker;
-				// blog(LOG_INFO, "tracker_state_first_track: %p rect=%d %d %d %d %f", t.tracker, t.rect.x0, t.rect.y0, t.rect.x1, t.rect.y1, t.rect.score);
+				debug_track("tracker_state_first_track %p %d %d %d %d %f", t.tracker, t.rect.x0, t.rect.y0, t.rect.x1, t.rect.y1, t.rect.score);
 				t.att = 1.0f;
 				stage_surface_to_tracker(s, t);
 				t.tracker->signal();
 				t.tracker->unlock();
-				t.state = tracker_inst_s::tracker_state_available;
+				if (ret)
+					t.state = tracker_inst_s::tracker_state_available;
 			}
 		}
 		else if (t.state == tracker_inst_s::tracker_state_available) {
 			if (!t.tracker->trylock()) {
 				t.tracker->get_face(t.rect);
 				t.crop_rect = t.crop_tracker;
-				// blog(LOG_INFO, "tracker_state_available: %p rect=%d %d %d %d %f", t.tracker, t.rect.x0, t.rect.y0, t.rect.x1, t.rect.y1, t.rect.score);
+				debug_track("tracker_state_available %p %d %d %d %d %f", t.tracker, t.rect.x0, t.rect.y0, t.rect.x1, t.rect.y1, t.rect.score);
 				stage_surface_to_tracker(s, t);
 				t.tracker->signal();
 				t.tracker->unlock();

--- a/src/texture-object.cpp
+++ b/src/texture-object.cpp
@@ -1,0 +1,44 @@
+#include <obs-module.h>
+#include <util/platform.h>
+#include <util/threading.h>
+#include <dlib/array2d/array2d_kernel.h>
+#include "plugin-macros.generated.h"
+#include "texture-object.h"
+
+struct texture_object_private_s
+{
+	dlib::array2d<unsigned char> dlib_img;
+};
+
+texture_object::texture_object()
+{
+	ref = 1;
+	data = new texture_object_private_s;
+}
+
+texture_object::~texture_object()
+{
+	delete data;
+}
+
+void texture_object::set_texture(uint8_t *data_, uint32_t linesize, uint32_t width, uint32_t height)
+{
+	// TODO: monochromed by GPU
+	data->dlib_img.set_size(height, width);
+	for (int i=0; i<height; i++) {
+		auto row = data->dlib_img[i];
+		uint8_t *line = data_+i*linesize;
+		for (int j=0; j<width; j++) {
+			// TODO: row[j] = line[j];
+			int r = line[j*4+0];
+			int g = line[j*4+1];
+			int b = line[j*4+2];
+			row[j] = (+306*r +601*g +117*b)/1024; // BT.601 // TODO
+		}
+	}
+}
+
+const dlib::array2d<unsigned char> &texture_object::get_dlib_img()
+{
+	return data->dlib_img;
+}

--- a/src/texture-object.cpp
+++ b/src/texture-object.cpp
@@ -21,20 +21,14 @@ texture_object::~texture_object()
 	delete data;
 }
 
-void texture_object::set_texture(uint8_t *data_, uint32_t linesize, uint32_t width, uint32_t height)
+void texture_object::set_texture_y(uint8_t *data_, uint32_t linesize, uint32_t width, uint32_t height)
 {
-	// TODO: monochromed by GPU
 	data->dlib_img.set_size(height, width);
 	for (int i=0; i<height; i++) {
 		auto row = data->dlib_img[i];
 		uint8_t *line = data_+i*linesize;
-		for (int j=0; j<width; j++) {
-			// TODO: row[j] = line[j];
-			int r = line[j*4+0];
-			int g = line[j*4+1];
-			int b = line[j*4+2];
-			row[j] = (+306*r +601*g +117*b)/1024; // BT.601 // TODO
-		}
+		for (int j=0; j<width; j++)
+			row[j] = line[j];
 	}
 }
 

--- a/src/texture-object.h
+++ b/src/texture-object.h
@@ -15,7 +15,7 @@ public:
 	void addref() { os_atomic_inc_long(&ref); }
 	void release() { if (os_atomic_dec_long(&ref)<=0) delete this; }
 
-	void set_texture(uint8_t *data, uint32_t linesize, uint32_t width, uint32_t height);
+	void set_texture_y(uint8_t *data, uint32_t linesize, uint32_t width, uint32_t height);
 	const dlib::array2d<unsigned char> &get_dlib_img();
 
 public:

--- a/src/texture-object.h
+++ b/src/texture-object.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <obs-module.h>
+#include <util/threading.h>
+#include <vector>
+#include <dlib/array2d/array2d_kernel.h>
+#include "plugin-macros.generated.h"
+
+class texture_object
+{
+	volatile long ref;
+	struct texture_object_private_s *data;
+public:
+	texture_object();
+	~texture_object();
+	void addref() { os_atomic_inc_long(&ref); }
+	void release() { if (os_atomic_dec_long(&ref)<=0) delete this; }
+
+	void set_texture(uint8_t *data, uint32_t linesize, uint32_t width, uint32_t height);
+	const dlib::array2d<unsigned char> &get_dlib_img();
+
+public:
+	int tick;
+	float scale;
+};


### PR DESCRIPTION
The new property `scale`, which was hard-coded `2`, is introduced to adjust scale of the frames going to face detection and tracking engine.
Also changes to draw Y in GPU so that the amount of data transferred from GPU to CPU will reduce to 1/16.

<!-- If unsure, feel free to let them unchecked. -->
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
