### PR TITLE
Fix memory leaks in face-tracker

### DIFF
--- a/src/face-detector-base.cpp
+++ b/src/face-detector-base.cpp
@@ -1,6 +1,7 @@
 #include <obs-module.h>
 #include <util/platform.h>
 #include <util/threading.h>
+#include <util/bmem.h>
 #include "plugin-macros.generated.h"
 #include "face-detector-base.h"
 #ifndef _WIN32
@@ -16,10 +17,12 @@ face_detector_base::face_detector_base()
 	pthread_cond_init(&cond, NULL);
 	request_stop = 0;
 	running = 0;
+	leak_test = bmalloc(1);
 }
 
 face_detector_base::~face_detector_base()
 {
+	bfree(leak_test);
 	pthread_cond_destroy(&cond);
 	pthread_mutex_destroy(&mutex);
 }

--- a/src/face-detector-base.h
+++ b/src/face-detector-base.h
@@ -12,6 +12,7 @@ class face_detector_base
 	pthread_cond_t cond;
 	bool running;
 	volatile bool request_stop;
+	void *leak_test;
 
 	static void* thread_routine(void *);
 	virtual void detect_main() = 0;

--- a/src/face-tracker-base.cpp
+++ b/src/face-tracker-base.cpp
@@ -1,6 +1,7 @@
 #include <obs-module.h>
 #include <util/platform.h>
 #include <util/threading.h>
+#include <util/bmem.h>
 #include "plugin-macros.generated.h"
 #include "face-tracker-base.h"
 #ifndef _WIN32
@@ -16,10 +17,12 @@ face_tracker_base::face_tracker_base()
 	pthread_cond_init(&cond, NULL);
 	stop_requested = 0;
 	running = 0;
+	leak_test = bmalloc(1);
 }
 
 face_tracker_base::~face_tracker_base()
 {
+	bfree(leak_test);
 	pthread_cond_destroy(&cond);
 	pthread_mutex_destroy(&mutex);
 }

--- a/src/face-tracker-base.h
+++ b/src/face-tracker-base.h
@@ -14,6 +14,7 @@ class face_tracker_base
 	volatile bool stop_requested;
 	volatile bool stopped;
 	volatile bool suspend_requested;
+	void *leak_test;
 
 	static void* thread_routine(void *);
 	virtual void track_main() = 0;

--- a/src/face-tracker-manager.cpp
+++ b/src/face-tracker-manager.cpp
@@ -177,6 +177,8 @@ inline void face_tracker_manager::stage_to_detector()
 		t.tick_cnt = tick_cnt;
 		t.tracker->set_texture(cvtex);
 		trackers.push_back(t);
+
+		cvtex->release();
 	}
 
 	detect->unlock();
@@ -188,6 +190,7 @@ inline int face_tracker_manager::stage_surface_to_tracker(struct tracker_inst_s 
 		t.tracker->set_texture(cvtex);
 		t.crop_tracker = crop_cur;
 		t.tracker->signal();
+		cvtex->release();
 	}
 	else
 		return 1;

--- a/src/face-tracker-manager.cpp
+++ b/src/face-tracker-manager.cpp
@@ -10,6 +10,7 @@
 // #define debug_detect(fmt, ...) blog(LOG_INFO, fmt, __VA_ARGS__)
 #define debug_track(fmt, ...)
 #define debug_detect(fmt, ...)
+#define debug_track_thread(fmt, ...) // blog(LOG_INFO, fmt, __VA_ARGS__)
 
 face_tracker_manager::face_tracker_manager()
 {
@@ -24,12 +25,27 @@ face_tracker_manager::face_tracker_manager()
 
 face_tracker_manager::~face_tracker_manager()
 {
+	for (auto &t : trackers_idlepool) {
+		if (t.tracker) {
+			t.tracker->stop();
+			delete t.tracker;
+			t.tracker = NULL;
+		}
+	}
+	for (auto &t : trackers) {
+		if (t.tracker) {
+			t.tracker->stop();
+			delete t.tracker;
+			t.tracker = NULL;
+		}
+	}
 	detect->stop();
 	delete detect;
 }
 
 inline void face_tracker_manager::retire_tracker(int ix)
 {
+	debug_track_thread("%p retire_tracker(%d %p)", this, ix, trackers[ix].tracker);
 	trackers_idlepool.push_back(trackers[ix]);
 	trackers[ix].tracker->request_suspend();
 	trackers.erase(trackers.begin()+ix);
@@ -98,7 +114,7 @@ inline void face_tracker_manager::copy_detector_to_tracker()
 		return;
 
 	if (detect_rects.size()<=0) {
-		trackers.erase(trackers.begin() + i_tracker);
+		retire_tracker(i_tracker);
 		return;
 	}
 
@@ -149,8 +165,13 @@ inline void face_tracker_manager::stage_to_detector()
 			trackers_idlepool[0].tracker = NULL;
 			trackers_idlepool.pop_front();
 		}
-		else
+		else {
+			debug_track_thread("%p No available idle tracker, creating new tracker thread. There are %d existing thread.", this, trackers.size());
 			t.tracker = new face_tracker_dlib();
+			for (int i=0; i<trackers.size(); i++) {
+				debug_track_thread("%p existing tracker[%d]: state=%d", this, i, (int)trackers[i].state);
+			}
+		}
 		t.crop_tracker = crop_cur;
 		t.state = tracker_inst_s::tracker_state_e::tracker_state_reset_texture;
 		t.tick_cnt = tick_cnt;

--- a/src/face-tracker.cpp
+++ b/src/face-tracker.cpp
@@ -139,6 +139,8 @@ static void ftf_destroy(void *data)
 	s->stagesurface = NULL;
 	obs_leave_graphics();
 
+	delete s->ftm;
+
 	bfree(s);
 }
 

--- a/src/texture-object.cpp
+++ b/src/texture-object.cpp
@@ -1,6 +1,7 @@
 #include <obs-module.h>
 #include <util/platform.h>
 #include <util/threading.h>
+#include <util/bmem.h>
 #include <dlib/array2d/array2d_kernel.h>
 #include "plugin-macros.generated.h"
 #include "texture-object.h"
@@ -12,16 +13,19 @@ static uint32_t formats_found = 0;
 struct texture_object_private_s
 {
 	dlib::array2d<unsigned char> dlib_img;
+	void *leak_test;
 };
 
 texture_object::texture_object()
 {
 	ref = 1;
 	data = new texture_object_private_s;
+	data->leak_test = bmalloc(1);
 }
 
 texture_object::~texture_object()
 {
+	bfree(data->leak_test);
 	delete data;
 }
 


### PR DESCRIPTION
Instances of `tracker_inst_s`, holding a pointer to `face_tracker_base` is accidentally removed in `face_tracker_manager::copy_detector_to_tracker()` when no face were detected. it causes number of face-tracker threads continuously increasing and also leaks memory that holds the object-tracker instance.

Releasing instances of `texture_object` was missing, which resulted a lot of memory leaks.

This PR also includes memory-leak test for two objects; `face_tracker_base` and `face_detector_base`. OBS Studio will alarm memory leaks. All C++ `new` are reviewed and added the leak test code.

<!-- If unsure, feel free to let them unchecked. -->
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
