### PR TITLE
ptz: FIx memory access violation introduced at 0.2.1

### DIFF
--- a/src/face-tracker-ptz.cpp
+++ b/src/face-tracker-ptz.cpp
@@ -75,6 +75,8 @@ class ft_manager_for_ftptz : public face_tracker_manager
 
 		class texture_object *get_cvtex() override
 		{
+			if (cvtex_cache)
+				cvtex_cache->addref();
 			return cvtex_cache;
 		};
 };

--- a/src/face-tracker.cpp
+++ b/src/face-tracker.cpp
@@ -25,12 +25,10 @@ class ft_manager_for_ftf : public face_tracker_manager
 {
 	public:
 		struct face_tracker_filter *ctx;
-		class texture_object *cvtex_cache;
 
 	public:
 		ft_manager_for_ftf(struct face_tracker_filter *ctx_) {
 			ctx = ctx_;
-			cvtex_cache = NULL;
 		}
 
 		~ft_manager_for_ftf()
@@ -40,15 +38,10 @@ class ft_manager_for_ftf : public face_tracker_manager
 
 		inline void release_cvtex()
 		{
-			if (cvtex_cache)
-				cvtex_cache->release();
-			cvtex_cache = NULL;
 		}
 
 		class texture_object *get_cvtex() override
 		{
-			if (cvtex_cache)
-				return cvtex_cache;
 			if (scale<1.0f) scale = 1.0f;
 			scale_texture(ctx, scale);
 			if (stage_to_surface(ctx, scale))


### PR DESCRIPTION
A memory-access violation was introduced by ce94c308, which add a missing release of a memory but it reveals incorrect addref in face-tracker-ptz.

<!-- If unsure, feel free to let them unchecked. -->
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.