### PR TITLE
face-tracker: Add attenuation property for zoom

### DIFF
--- a/doc/properties.md
+++ b/doc/properties.md
@@ -72,6 +72,10 @@ Larger value will make faster tracking when the subject start to move.
 This is an inverse of the cut-off frequency for the low-pass filter (LPF), which affects the derivative term of PID control element. The dimention is time and the unit is s.
 The LPF will reduce noise of face detection and small move of the subject.
 
+### Attenuation (Z)
+This is another proportional constant that affects only the zoom factor.
+Smaller value will result in slower response of the zoom.
+
 ### Dead band nonlinear band (X, Y, Z)
 These parameters make dead bands and nonlinear bands for the error signal that goes to PID control element.
 The unit is a percentage of the average of source width and height.

--- a/src/face-tracker.hpp
+++ b/src/face-tracker.hpp
@@ -26,9 +26,9 @@ struct face_tracker_filter
 	float track_z, track_x, track_y;
 	float scale_max;
 
-	float kp;
+	f3 kp;
 	float ki;
-	float klpf;
+	f3 klpf;
 	float tlpf;
 	f3 e_deadband, e_nonlinear; // deadband and nonlinear amount for error input
 	f3 filter_int_out;

--- a/src/helper.hpp
+++ b/src/helper.hpp
@@ -30,6 +30,8 @@ struct f3
 	f3 operator - (const f3 &a) { return f3 (v[0]-a.v[0], v[1]-a.v[1], v[2]-a.v[2]); }
 	f3 operator * (float a) { return f3 (v[0]*a, v[1]*a, v[2]*a); }
 	f3 & operator += (const f3 &a) { return *this = f3 (v[0]+a.v[0], v[1]+a.v[1], v[2]+a.v[2]); }
+
+	f3 hp (const f3 &a) const { return f3 (v[0]*a.v[0], v[1]*a.v[1], v[2]*a.v[2]); }
 };
 
 static inline bool isnan(const f3 &a) { return isnan(a.v[0]) || isnan(a.v[1]) || isnan(a.v[2]); }


### PR DESCRIPTION
Size of the detected face heavily depends on the frame and appearance of the face. It results frequent zoom in and out.
Users are suggested to reduce the attenuation to avoid too much zoom change.

This is a redo of #71.

<!-- If unsure, feel free to let them unchecked. -->
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
