### PR TITLE
Separate LPF parameter for zoom

### DIFF
--- a/src/face-tracker-ptz.hpp
+++ b/src/face-tracker-ptz.hpp
@@ -21,7 +21,7 @@ struct face_tracker_ptz
 	float kp_x, kp_y, kp_z;
 	float ki;
 	float klpf;
-	float tlpf;
+	f3 tlpf;
 	f3 e_deadband, e_nonlinear; // deadband and nonlinear amount for error input
 	f3 filter_int;
 	f3 filter_lpf;

--- a/src/face-tracker.hpp
+++ b/src/face-tracker.hpp
@@ -29,7 +29,7 @@ struct face_tracker_filter
 	f3 kp;
 	float ki;
 	f3 klpf;
-	float tlpf;
+	f3 tlpf;
 	f3 e_deadband, e_nonlinear; // deadband and nonlinear amount for error input
 	f3 filter_int_out;
 	f3 filter_int;


### PR DESCRIPTION
To reduce fluctuation of zoom, LPF parameter for zoom axis is separated from other pan and tilt axises.


<!-- If unsure, feel free to let them unchecked. -->
- [ ] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
