### PR TITLE
Move _USE_MATH_DEFINES before including obs headers

### DIFF
--- a/src/face-tracker.cpp
+++ b/src/face-tracker.cpp
@@ -1,13 +1,11 @@
+#ifdef _WIN32
+#define _USE_MATH_DEFINES
+#endif // _WIN32
 #include <obs-module.h>
 #include <util/platform.h>
 #include <util/threading.h>
 #include <graphics/vec2.h>
 #include <graphics/graphics.h>
-#undef M_PI
-#ifdef _WIN32
-#define _USE_MATH_DEFINES
-#endif // _WIN32
-#include <cmath>
 #include "plugin-macros.generated.h"
 #include "texture-object.h"
 #include <algorithm>


### PR DESCRIPTION
The header file math.h is included inside a header file from OBS Studio.
Define `_USE_MATH_DEFINES` so that M_PI is defined by that include.


<!-- If unsure, feel free to let them unchecked. -->
- [ ] The commit is reviewed by yourself.
- [ ] The code is tested.
- [ ] Document is up to date or not necessary to be changed.
- [ ] The commit is compatible with repository's license.
