### PR TITLE
ptz: Update procedure for new ABI on obs-ptz

### DIFF
--- a/src/face-tracker-ptz.cpp
+++ b/src/face-tracker-ptz.cpp
@@ -633,8 +633,7 @@ static inline void send_ptz_cmd_immediate(struct face_tracker_ptz *s)
 	}
 
 	if (s->ftm->dev && s->ftm->can_send_ptz_cmd()) {
-		s->ftm->dev->set_pantilt_speed(s->u[0], s->u[1]);
-		s->ftm->dev->set_zoom_speed(s->u[2]);
+		s->ftm->dev->set_pantiltzoom_speed(s->u[0], s->u[1], s->u[2]);
 	}
 
 	s->u_prev1[0] = s->u_prev[0];

--- a/src/libvisca-thread.hpp
+++ b/src/libvisca-thread.hpp
@@ -25,10 +25,10 @@ public:
 
 	void set_config(struct obs_data *data) override; // and attempt to connect
 
-	void set_pantilt_speed(int pan, int tilt) override {
+	void set_pantiltzoom_speed(int pan, int tilt, int zoom) override {
 		os_atomic_set_long(&pan_rsvd, pan);
 		os_atomic_set_long(&tilt_rsvd, tilt);
+		os_atomic_set_long(&zoom_rsvd, zoom);
 	}
-	void set_zoom_speed(int zoom) override { os_atomic_set_long(&zoom_rsvd, zoom); }
 	int get_zoom() override { return os_atomic_load_long(&zoom_got); }
 };

--- a/src/obsptz-backend.hpp
+++ b/src/obsptz-backend.hpp
@@ -5,6 +5,11 @@ class obsptz_backend : public ptz_backend
 {
 	uint64_t available_ns = 0;
 	int device_id = -1;
+	proc_handler_t *ptz_ph = NULL;
+	proc_handler_t *get_ptz_ph();
+	int prev_pan = 0;
+	int prev_tilt = 0;
+	int prev_zoom = 0;
 public:
 	obsptz_backend();
 	~obsptz_backend() override;
@@ -12,7 +17,6 @@ public:
 	void set_config(struct obs_data *data) override;
 	bool can_send() override;
 	void tick() override;
-	void set_pantilt_speed(int pan, int tilt) override;
-	void set_zoom_speed(int zoom) override;
+	void set_pantiltzoom_speed(int pan, int tilt, int zoom) override;
 	int get_zoom() override;
 };

--- a/src/ptz-backend.hpp
+++ b/src/ptz-backend.hpp
@@ -17,7 +17,6 @@ public:
 
 	virtual bool can_send() { return true; }
 	virtual void tick() {}
-	virtual void set_pantilt_speed(int pan, int tilt) = 0;
-	virtual void set_zoom_speed(int zoom) = 0;
+	virtual void set_pantiltzoom_speed(int pan, int tilt, int zoom) = 0;
 	virtual int get_zoom() = 0;
 };


### PR DESCRIPTION
Use `ptz_move_continuous` instead of `ptz_pantilt` so that zoom can be set.
This commit also suppresses amount of PTZ commands if there is no need to change from the previous command.


<!-- If unsure, feel free to let them unchecked. -->
- [ ] The commit is reviewed by yourself.
- [x] The code is tested.
  - Tested with the commit 1bf2e01 in [obs-ptz](https://github.com/glikely/obs-ptz).
  - Tested with v0.10.2 in [obs-ptz](https://github.com/glikely/obs-ptz).
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
