### PR TITLE
ptz: Several fixes for PTZ Control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,7 @@ if(WIN32)
     # Enable Multicore Builds and disable FH4 (to not depend on VCRUNTIME140_1.DLL when building with VS2019)
     if (MSVC)
         add_definitions(/MP /d2FH4-)
+        add_definitions("-D_USE_MATH_DEFINES")
     endif()
 
 	if(CMAKE_SIZEOF_VOID_P EQUAL 8)

--- a/doc/properties-ptz.md
+++ b/doc/properties-ptz.md
@@ -78,6 +78,9 @@ The unit is a percentage of the average of source width and height.
 If the error signal is within the dead band, error signal is forced to zero to avoid small move to be tracked.
 The nonlinear band makes smooth connection from the dead band to the linear range.
 
+### Attenuation time for lost face
+After the face is lost, integral term will be attenuated by this time. The dimension is time and the unit is s.
+
 ## Debug
 These properties enables how the face detection and tracking works.
 Note that these features are automatically turned off when the source is displayed on the program of OBS Studio.

--- a/doc/properties-ptz.md
+++ b/doc/properties-ptz.md
@@ -38,6 +38,12 @@ Larger value will reduce CPU usage but too large value will fail to detect faces
 The face detection engine requires size of the faces at least 80x80.
 If you have low resolution image, it is highly recommended to set to `1`.
 
+### Tracking threshold
+This property sets the threshold when to stop tracking after the face is lost.
+During correlation tracking, scores are accumulated.
+When the score drops lower than the specified threshold,
+the tracking will be stopped.
+
 ## Tracking target location
 
 ### Zoom

--- a/doc/properties-ptz.md
+++ b/doc/properties-ptz.md
@@ -66,16 +66,16 @@ Since the gain of the PTZ camera depends on the manufactures and models,
 you need to adjust Kp for your camera.
 
 ### Ki
-This is a integral constant. The dimention is inverse time and the unit is s<sup>-1</sup>.
+This is a integral constant. The dimension is inverse time and the unit is s<sup>-1</sup>.
 Larger value results more tracking of slow move.
 
 ### Td
-This is a derivative constant. The dimention is time and the unit is s.
+This is a derivative constant. The dimension is time and the unit is s.
 0 will result no derivative term.
 Larger value will make faster tracking when the subject start to move.
 
 ### LPF for Td
-This is an inverse of the cut-off frequency for the low-pass filter (LPF), which affects the derivative term of PID control element. The dimention is time and the unit is s.
+This is an inverse of the cut-off frequency for the low-pass filter (LPF), which affects the derivative term of PID control element. The dimension is time and the unit is s.
 The LPF will reduce noise of face detection and small move of the subject.
 
 ### Dead band nonlinear band (X, Y, Z)

--- a/doc/properties.md
+++ b/doc/properties.md
@@ -69,20 +69,20 @@ This property set the maximum of the zoom.
 The tracking system has a PID control element + integrator.
 
 ### Kp
-This is a proportional constant. The dimention is inverse time and the unit is s<sup>-1</sup>.
+This is a proportional constant. The dimension is inverse time and the unit is s<sup>-1</sup>.
 Larger value will result faster response.
 
 ### Ki
-This is a integral constant. The dimention is inverse time and the unit is s<sup>-1</sup>.
+This is a integral constant. The dimension is inverse time and the unit is s<sup>-1</sup>.
 Larger value results more tracking of slow move.
 
 ### Td
-This is a derivative constant. The dimention is time and the unit is s.
+This is a derivative constant. The dimension is time and the unit is s.
 0 will result no derivative term.
 Larger value will make faster tracking when the subject start to move.
 
 ### LPF for Td
-This is an inverse of the cut-off frequency for the low-pass filter (LPF), which affects the derivative term of PID control element. The dimention is time and the unit is s.
+This is an inverse of the cut-off frequency for the low-pass filter (LPF), which affects the derivative term of PID control element. The dimension is time and the unit is s.
 The LPF will reduce noise of face detection and small move of the subject.
 
 ### Attenuation (Z)

--- a/doc/properties.md
+++ b/doc/properties.md
@@ -44,6 +44,12 @@ If your resolution is much smaller, make a intermediate scene and apply face tra
 1. Apply the filter to the scene.
 1. Put the scene to your desired scene.
 
+### Tracking threshold
+This property sets the threshold when to stop tracking after the face is lost.
+During correlation tracking, scores are accumulated.
+When the score drops lower than the specified threshold,
+the tracking will be stopped.
+
 ## Tracking target location
 
 ### Zoom

--- a/src/face-tracker-manager.hpp
+++ b/src/face-tracker-manager.hpp
@@ -18,6 +18,7 @@ class face_tracker_manager
 			rectf_s crop_tracker; // crop corresponding to current processing image
 			rectf_s crop_rect; // crop corresponding to rect
 			float att;
+			float score_first;
 			enum tracker_state_e {
 				tracker_state_init = 0,
 				tracker_state_reset_texture, // texture has been set, position is not set.
@@ -33,6 +34,7 @@ class face_tracker_manager
 		float upsize_l, upsize_r, upsize_t, upsize_b;
 		volatile float scale;
 		volatile bool reset_requested;
+		float tracking_threshold;
 
 	public: // realtime status
 		rectf_s crop_cur;
@@ -67,6 +69,7 @@ class face_tracker_manager
 
 	private:
 		inline void retire_tracker(int ix);
+		inline bool is_low_confident(const tracker_inst_s &t, float th1);
 		void attenuate_tracker();
 		void copy_detector_to_tracker();
 		void stage_to_detector();

--- a/src/face-tracker-ptz.cpp
+++ b/src/face-tracker-ptz.cpp
@@ -71,13 +71,21 @@ class ft_manager_for_ftptz : public face_tracker_manager
 			return false;
 		}
 
+		void release_dev() {
+			if (dev) {
+				dev->set_pantilt_speed(0, 0);
+				dev->set_zoom_speed(0);
+				dev->release();
+				dev = NULL;
+			}
+		}
+
 		~ft_manager_for_ftptz()
 		{
 			release_cvtex();
 			if (ptzdev)
 				delete ptzdev;
-			if (dev)
-				dev->release();
+			release_dev();
 		}
 
 		inline void release_cvtex()
@@ -169,10 +177,7 @@ static obs_data_t *get_ptz_settings(obs_data_t *settings)
 
 static void make_ptz_device(struct face_tracker_ptz *s, const char *ptz_type, obs_data_t *data)
 {
-	if (s->ftm->dev) {
-		s->ftm->dev->release();
-		s->ftm->dev = NULL;
-	}
+	s->ftm->release_dev();
 
 	if (s->ftm->ptzdev)
 		delete s->ftm->ptzdev;
@@ -187,10 +192,7 @@ static void make_deice_obsptz(struct face_tracker_ptz *s, const char *ptz_type, 
 		s->ftm->ptzdev = NULL;
 	}
 
-	if (s->ftm->dev) {
-		s->ftm->dev->release();
-		s->ftm->dev = NULL;
-	}
+	s->ftm->release_dev();
 
 	s->ftm->dev = new obsptz_backend();
 	s->ftm->dev->set_config(data);
@@ -204,10 +206,7 @@ static void make_device_libvisca_tcp(struct face_tracker_ptz *s, const char *ptz
 		s->ftm->ptzdev = NULL;
 	}
 
-	if (s->ftm->dev) {
-		s->ftm->dev->release();
-		s->ftm->dev = NULL;
-	}
+	s->ftm->release_dev();
 
 	if (!obs_data_get_string(data, "address"))
 		return;

--- a/src/face-tracker-ptz.cpp
+++ b/src/face-tracker-ptz.cpp
@@ -6,7 +6,6 @@
 #include "plugin-macros.generated.h"
 #include "texture-object.h"
 #include <algorithm>
-#include <cmath>
 #include <graphics/matrix4.h>
 #include "helper.hpp"
 #include "face-tracker-ptz.hpp"
@@ -230,9 +229,9 @@ static void ftptz_update(void *data, obs_data_t *settings)
 	float inv_x = obs_data_get_bool(settings, "invert_x") ? -1.0f : 1.0f;
 	float inv_y = obs_data_get_bool(settings, "invert_y") ? -1.0f : 1.0f;
 	float inv_z = obs_data_get_bool(settings, "invert_z") ? -1.0f : 1.0f;
-	s->kp_x = powf(10.0f, (float)obs_data_get_double(settings, "Kp_x_db")/20.0f) * inv_x;
-	s->kp_y = powf(10.0f, (float)obs_data_get_double(settings, "Kp_y_db")/20.0f) * inv_y;
-	s->kp_z = powf(10.0f, (float)obs_data_get_double(settings, "Kp_z_db")/20.0f) * inv_z;
+	s->kp_x = (float)from_dB(obs_data_get_double(settings, "Kp_x_db")) * inv_x;
+	s->kp_y = (float)from_dB(obs_data_get_double(settings, "Kp_y_db")) * inv_y;
+	s->kp_z = (float)from_dB(obs_data_get_double(settings, "Kp_z_db")) * inv_z;
 	s->ki = ki;
 	s->klpf = (float)td;
 	s->tlpf.v[0] = s->tlpf.v[1] = (float)obs_data_get_double(settings, "Tdlpf");
@@ -452,6 +451,7 @@ static void ftptz_get_defaults(obs_data_t *settings)
 	obs_data_set_default_bool(settings, "preset_mask_track", true);
 	obs_data_set_default_bool(settings, "preset_mask_control", true);
 	face_tracker_manager::get_defaults(settings);
+	obs_data_set_default_double(settings, "tracking_th_dB", -40.0); // overwrite the default from face_tracker_manager
 	obs_data_set_default_double(settings, "track_z",  0.25); // Smaller is preferable for PTZ not to lose the face.
 	obs_data_set_default_double(settings, "track_y", +0.00); // +0.00 +0.10 +0.30
 

--- a/src/face-tracker-ptz.hpp
+++ b/src/face-tracker-ptz.hpp
@@ -13,6 +13,7 @@ struct face_tracker_ptz
 	bool is_active;
 
 	f3 detect_err;
+	bool face_found, face_found_last;
 
 	class ft_manager_for_ftptz *ftm;
 
@@ -25,6 +26,7 @@ struct face_tracker_ptz
 	f3 e_deadband, e_nonlinear; // deadband and nonlinear amount for error input
 	f3 filter_int;
 	f3 filter_lpf;
+	float f_att_int;
 	int u[3];
 	int u_prev[3];
 	int u_prev1[3];

--- a/src/face-tracker.cpp
+++ b/src/face-tracker.cpp
@@ -1,6 +1,3 @@
-#ifdef _WIN32
-#define _USE_MATH_DEFINES
-#endif // _WIN32
 #include <obs-module.h>
 #include <util/platform.h>
 #include <util/threading.h>
@@ -82,7 +79,7 @@ static void ftf_update(void *data, obs_data_t *settings)
 	double kp = obs_data_get_double(settings, "Kp");
 	float ki = (float)obs_data_get_double(settings, "Ki");
 	double td = obs_data_get_double(settings, "Td");
-	double att2 = exp(obs_data_get_double(settings, "att2_dB") * (M_LN10/20));
+	double att2 = from_dB(obs_data_get_double(settings, "att2_dB"));
 	s->kp.v[0] = s->kp.v[1] = (float)kp;
 	s->kp.v[2] = (float)(att2 * kp);
 	s->ki = ki;

--- a/src/helper.hpp
+++ b/src/helper.hpp
@@ -112,3 +112,8 @@ static inline void draw_rect_upsize(rect_s r, float upsize_l=0.0f, float upsize_
 
 	gs_render_stop(GS_LINES);
 }
+
+inline double from_dB(double x)
+{
+	return exp(x * (M_LN10/20));
+}

--- a/src/libvisca-thread.hpp
+++ b/src/libvisca-thread.hpp
@@ -25,10 +25,10 @@ public:
 
 	void set_config(struct obs_data *data) override; // and attempt to connect
 
-	void set_pantiltzoom_speed(int pan, int tilt, int zoom) override {
+	void set_pantilt_speed(int pan, int tilt) override {
 		os_atomic_set_long(&pan_rsvd, pan);
 		os_atomic_set_long(&tilt_rsvd, tilt);
-		os_atomic_set_long(&zoom_rsvd, zoom);
 	}
+	void set_zoom_speed(int zoom) override { os_atomic_set_long(&zoom_rsvd, zoom); }
 	int get_zoom() override { return os_atomic_load_long(&zoom_got); }
 };

--- a/src/obsptz-backend.hpp
+++ b/src/obsptz-backend.hpp
@@ -17,6 +17,7 @@ public:
 	void set_config(struct obs_data *data) override;
 	bool can_send() override;
 	void tick() override;
-	void set_pantiltzoom_speed(int pan, int tilt, int zoom) override;
+	void set_pantilt_speed(int pan, int tilt) override;
+	void set_zoom_speed(int zoom) override;
 	int get_zoom() override;
 };

--- a/src/ptz-backend.hpp
+++ b/src/ptz-backend.hpp
@@ -17,6 +17,7 @@ public:
 
 	virtual bool can_send() { return true; }
 	virtual void tick() {}
-	virtual void set_pantiltzoom_speed(int pan, int tilt, int zoom) = 0;
+	virtual void set_pantilt_speed(int pan, int tilt) = 0;
+	virtual void set_zoom_speed(int zoom) = 0;
 	virtual int get_zoom() = 0;
 };


### PR DESCRIPTION
This PR fixes several issues use with obs-ptz plugin.

- Fix an issue the zoom command was ignored for UDP-connected camera
- Fix an issue PTZ camera keeps moving when disconnected or face has gone
- Add a new option to adjust threshold of tracking

<!-- If unsure, feel free to let them unchecked. -->
- [ ] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
