### PR TITLE
Add a new feature to crop image for face detection

### DIFF
--- a/doc/properties-ptz.md
+++ b/doc/properties-ptz.md
@@ -38,6 +38,14 @@ Larger value will reduce CPU usage but too large value will fail to detect faces
 The face detection engine requires size of the faces at least 80x80.
 If you have low resolution image, it is highly recommended to set to `1`.
 
+### Crop left, right, top, and bottom for detector
+These properties crop the image before sending to the face detection algorithm.
+The unit is pixel before scaling the image.
+
+The properties won't affect tracking.
+If the face is once detected and moved out from the cropped region,
+the tracking will still continue.
+
 ### Tracking threshold
 This property sets the threshold when to stop tracking after the face is lost.
 During correlation tracking, scores are accumulated.

--- a/doc/properties.md
+++ b/doc/properties.md
@@ -44,6 +44,14 @@ If your resolution is much smaller, make a intermediate scene and apply face tra
 1. Apply the filter to the scene.
 1. Put the scene to your desired scene.
 
+### Crop left, right, top, and bottom for detector
+These properties crop the image before sending to the face detection algorithm.
+The unit is pixel before scaling the image.
+
+The properties won't affect tracking.
+If the face is once detected and moved out from the cropped region,
+the tracking will still continue.
+
 ### Tracking threshold
 This property sets the threshold when to stop tracking after the face is lost.
 During correlation tracking, scores are accumulated.

--- a/src/face-detector-base.h
+++ b/src/face-detector-base.h
@@ -26,7 +26,7 @@ class face_detector_base
 		int unlock() { return pthread_mutex_unlock(&mutex); }
 		int signal() { return pthread_cond_signal(&cond); }
 
-		virtual void set_texture(class texture_object *) = 0;
+		virtual void set_texture(class texture_object *, int crop_l, int crop_r, int crop_t, int crop_b) = 0;
 		virtual void get_faces(std::vector<struct rect_s> &) = 0;
 
 		void start();

--- a/src/face-detector-dlib.cpp
+++ b/src/face-detector-dlib.cpp
@@ -12,6 +12,7 @@ struct face_detector_dlib_private_s
 	texture_object *tex;
 	std::vector<rect_s> rects;
 	dlib::frontal_face_detector *detector;
+	int crop_l = 0, crop_r = 0, crop_t = 0, crop_b = 0;
 	face_detector_dlib_private_s()
 	{
 		tex = NULL;
@@ -31,32 +32,53 @@ face_detector_dlib::~face_detector_dlib()
 	delete p;
 }
 
-void face_detector_dlib::set_texture(texture_object *tex)
+void face_detector_dlib::set_texture(texture_object *tex, int crop_l, int crop_r, int crop_t, int crop_b)
 {
 	if (p->tex) p->tex->release();
 	tex->addref();
 	p->tex = tex;
+	p->crop_l = crop_l;
+	p->crop_r = crop_r;
+	p->crop_t = crop_t;
+	p->crop_b = crop_b;
 }
 
 void face_detector_dlib::detect_main()
 {
 	if (!p->tex)
 		return;
-	const dlib::array2d<unsigned char> &img = p->tex->get_dlib_img();
-	if (img.nc()<80 || img.nr()<80)
+	const dlib::array2d<unsigned char> *img = &p->tex->get_dlib_img();
+	int x0 = 0, y0 = 0;
+	dlib::array2d<unsigned char> img_crop;
+	if (p->crop_l > 0 || p->crop_r > 0 || p->crop_t > 0 || p->crop_b > 0) {
+		x0 = (int)(p->crop_l / p->tex->scale);
+		int x1 = img->nc() - (int)(p->crop_r / p->tex->scale);
+		y0 = (int)(p->crop_t / p->tex->scale);
+		int y1 = img->nr() - (int)(p->crop_b / p->tex->scale);
+		if (x1 - x0 < 80 || y1 - y0 < 80)
+			return;
+		img_crop.set_size(y1 - y0, x1 - x0);
+		for (int y = y0; y < y1; y++) {
+			for (int x = x0; x < x1; x++) {
+				img_crop[y-y0][x-x0] = (*img)[y][x];
+			}
+		}
+		img = &img_crop;
+	}
+	if (img->nc()<80 || img->nr()<80)
 		return;
 
 	if (!p->detector)
 		p->detector = new dlib::frontal_face_detector(dlib::get_frontal_face_detector());
 
-	std::vector<dlib::rectangle> dets = (*p->detector)(img);
+	std::vector<dlib::rectangle> dets = (*p->detector)(*img);
 	p->rects.resize(dets.size());
 	for (size_t i=0; i<dets.size(); i++) {
 		rect_s &r = p->rects[i];
-		r.x0 = dets[i].left() * p->tex->scale;
-		r.y0 = dets[i].top() * p->tex->scale;
-		r.x1 = dets[i].right() * p->tex->scale;
-		r.y1 = dets[i].bottom() * p->tex->scale;
+		r.x0 = (dets[i].left() + x0) * p->tex->scale;
+		r.y0 = (dets[i].top() + y0) * p->tex->scale;
+		r.x1 = (dets[i].right() + x0) * p->tex->scale;
+		r.y1 = (dets[i].bottom() + y0) * p->tex->scale;
 		r.score = 1.0; // TODO: implement me
 	}
 

--- a/src/face-detector-dlib.h
+++ b/src/face-detector-dlib.h
@@ -12,6 +12,6 @@ class face_detector_dlib : public face_detector_base
 	public:
 		face_detector_dlib();
 		virtual ~face_detector_dlib();
-		void set_texture(class texture_object *) override;
+		void set_texture(class texture_object *, int crop_l, int crop_r, int crop_t, int crop_b) override;
 		void get_faces(std::vector<struct rect_s> &) override;
 };

--- a/src/face-tracker-manager.cpp
+++ b/src/face-tracker-manager.cpp
@@ -166,7 +166,9 @@ inline void face_tracker_manager::stage_to_detector()
 	}
 
 	if (class texture_object *cvtex = get_cvtex()) {
-		detect->set_texture(cvtex);
+		detect->set_texture(cvtex,
+				detector_crop_l, detector_crop_r,
+				detector_crop_t, detector_crop_b );
 		detect->signal();
 		detector_in_progress = true;
 		detect_tick = tick_cnt;
@@ -296,6 +298,10 @@ void face_tracker_manager::update(obs_data_t *settings)
 	upsize_t = obs_data_get_double(settings, "upsize_t");
 	upsize_b = obs_data_get_double(settings, "upsize_b");
 	scale = obs_data_get_double(settings, "scale");
+	detector_crop_l = obs_data_get_int(settings, "detector_crop_l");
+	detector_crop_r = obs_data_get_int(settings, "detector_crop_r");
+	detector_crop_t = obs_data_get_int(settings, "detector_crop_t");
+	detector_crop_b = obs_data_get_int(settings, "detector_crop_b");
 	tracking_threshold = from_dB(obs_data_get_double(settings, "tracking_th_dB"));
 }
 
@@ -307,6 +313,10 @@ void face_tracker_manager::get_properties(obs_properties_t *pp)
 	obs_properties_add_float(pp, "upsize_t", obs_module_text("Top"), -0.4, 4.0, 0.2);
 	obs_properties_add_float(pp, "upsize_b", obs_module_text("Bottom"), -0.4, 4.0, 0.2);
 	obs_properties_add_float(pp, "scale", obs_module_text("Scale image"), 1.0, 16.0, 1.0);
+	obs_properties_add_int(pp, "detector_crop_l", obs_module_text("Crop left for detector"), 0, 1920, 1);
+	obs_properties_add_int(pp, "detector_crop_r", obs_module_text("Crop right for detector"), 0, 1920, 1);
+	obs_properties_add_int(pp, "detector_crop_t", obs_module_text("Crop top for detector"), 0, 1080, 1);
+	obs_properties_add_int(pp, "detector_crop_b", obs_module_text("Crop bottom for detector"), 0, 1080, 1);
 	p = obs_properties_add_float(pp, "tracking_th_dB", obs_module_text("Tracking threshold"), -120.0, -20.0, 5.0);
 	obs_property_float_set_suffix(p, " dB");
 }

--- a/src/face-tracker-manager.hpp
+++ b/src/face-tracker-manager.hpp
@@ -35,6 +35,7 @@ class face_tracker_manager
 		volatile float scale;
 		volatile bool reset_requested;
 		float tracking_threshold;
+		int detector_crop_l, detector_crop_r, detector_crop_t, detector_crop_b;
 
 	public: // realtime status
 		rectf_s crop_cur;


### PR DESCRIPTION
This commit adds a feature to crop images before the face detection algorithm. The feature is available for both plain and PTZ filters. The feature won't change tracking so that the image is cropped in the face-detection thread.

<!-- If unsure, feel free to let them unchecked. -->
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.

Close #66