### PR TITLE
Implement face landmark detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ set(PLUGIN_SOURCES
 	src/face-tracker-base.cpp
 	src/face-tracker-dlib.cpp
 	src/texture-object.cpp
+	src/helper.cpp
 	src/ptz-backend.cpp
 	src/obsptz-backend.cpp
 	src/dummy-backend.cpp

--- a/ci/linux/build-ubuntu.sh
+++ b/ci/linux/build-ubuntu.sh
@@ -8,6 +8,10 @@ patch -p1 < ../ci/common/dlib-slim.patch
 patch -p1 < ../ci/common/dlib-cmake-no-openblasp.patch
 cd ..
 
+git clone --depth 1 https://github.com/davisking/dlib-models
+bunzip2 < dlib-models/shape_predictor_5_face_landmarks.dat.bz2 > data/shape_predictor_5_face_landmarks.dat
+cp dlib-models/LICENSE data/LICENSE-dlib-models
+
 cp LICENSE data/LICENSE-$PLUGIN_NAME
 cp dlib/LICENSE.txt data/LICENSE-dlib
 

--- a/ci/macos/build-macos.sh
+++ b/ci/macos/build-macos.sh
@@ -23,6 +23,10 @@ patch -p1 < ../ci/common/dlib-slim.patch
 patch -p1 < ../ci/common/dlib-cmake-no-openblasp.patch
 cd ..
 
+echo "=> Cloning dlib-models..."
+git clone --depth 1 https://github.com/davisking/dlib-models
+bunzip2 < dlib-models/shape_predictor_5_face_landmarks.dat.bz2 > data/shape_predictor_5_face_landmarks.dat
+
 #export QT_PREFIX="$(find /usr/local/Cellar/qt5 -d 1 | tail -n 1)"
 
 export OPENBLAS_HOME=/usr/local/opt/openblas/

--- a/ci/macos/package-macos.sh
+++ b/ci/macos/package-macos.sh
@@ -74,6 +74,7 @@ mkdir -p $ziproot/bin
 cp ./build/$PLUGIN_NAME.so $ziproot/bin/
 cp LICENSE data/LICENSE-$PLUGIN_NAME
 cp dlib/LICENSE.txt data/LICENSE-dlib
+cp dlib-models/LICENSE data/LICENSE-dlib-models
 cp -a data $ziproot/
 mkdir -p ./release
 rmdir lib || mv lib $ziproot/

--- a/ci/windows/package-windows.cmd
+++ b/ci/windows/package-windows.cmd
@@ -9,6 +9,7 @@ del package-version.txt
 
 copy ..\LICENSE          ..\release\data\obs-plugins\%PluginName%\LICENCE-%PluginName%.txt
 copy ..\dlib\LICENSE.txt ..\release\data\obs-plugins\%PluginName%\LICENSE-dlib.txt
+copy ..\dlib-models\LICENSE ..\release\data\obs-plugins\%PluginName%\LICENSE-dlib-models.txt
 
 REM Package ZIP archive
 7z a "%PluginName%-%PackageVersion%-Windows.zip" "..\release\*"

--- a/ci/windows/prepare-windows.cmd
+++ b/ci/windows/prepare-windows.cmd
@@ -10,6 +10,12 @@ if not exist dlib (
 	cd ..
 )
 
+if not exist dlib-models (
+	echo checkout dlib...
+	git clone --depth 1 https://github.com/davisking/dlib-models
+)
+7z x dlib-models/shape_predictor_5_face_landmarks.dat.bz2 -so > data/shape_predictor_5_face_landmarks.dat
+
 if "%buildWin32%" == "false" goto skippedWin32
 mkdir build32
 cd build32

--- a/doc/properties-ptz.md
+++ b/doc/properties-ptz.md
@@ -46,6 +46,17 @@ The properties won't affect tracking.
 If the face is once detected and moved out from the cropped region,
 the tracking will still continue.
 
+### Landmark detection
+Specify dataset for face landmark detection and enable the checkbox
+to calculate location and size of the face.
+The location is calculated by the average of all the landmark points for each face.
+The size is calculated by the area surrounded by the landmark points.
+You might need to adjust tracking target location and zoom depending on the landmark datasets.
+
+A dataset file `shape_predictor_5_face_landmarks.dat` is bundled so that you can try it soon.
+Original data is distributed at [dlib-models](https://github.com/davisking/dlib-models).
+Another model `shape_predictor_68_face_landmarks.dat` is ready but not bundled due to a license incompatibility.
+
 ### Tracking threshold
 This property sets the threshold when to stop tracking after the face is lost.
 During correlation tracking, scores are accumulated.

--- a/doc/properties.md
+++ b/doc/properties.md
@@ -52,6 +52,17 @@ The properties won't affect tracking.
 If the face is once detected and moved out from the cropped region,
 the tracking will still continue.
 
+### Landmark detection
+Specify dataset for face landmark detection and enable the checkbox
+to calculate location and size of the face.
+The location is calculated by the average of all the landmark points for each face.
+The size is calculated by the area surrounded by the landmark points.
+You might need to adjust tracking target location and zoom depending on the landmark datasets.
+
+A dataset file `shape_predictor_5_face_landmarks.dat` is bundled so that you can try it soon.
+Original data is distributed at [dlib-models](https://github.com/davisking/dlib-models).
+Another model `shape_predictor_68_face_landmarks.dat` is ready but not bundled due to a license incompatibility.
+
 ### Tracking threshold
 This property sets the threshold when to stop tracking after the face is lost.
 During correlation tracking, scores are accumulated.

--- a/src/face-tracker-base.h
+++ b/src/face-tracker-base.h
@@ -30,7 +30,10 @@ class face_tracker_base
 
 		virtual void set_texture(class texture_object *) = 0;
 		virtual void set_position(const rect_s &rect) = 0;
+		virtual void set_upsize_info(const rectf_s &upsize) = 0;
+		virtual void set_landmark_detection(const char *data_file_path) = 0;
 		virtual bool get_face(struct rect_s &) = 0;
+		virtual bool get_landmark(std::vector<pointf_s> &) = 0;
 
 		void start();
 		void stop();

--- a/src/face-tracker-dlib.h
+++ b/src/face-tracker-dlib.h
@@ -15,5 +15,8 @@ class face_tracker_dlib : public face_tracker_base
 
 		void set_texture(texture_object *) override;
 		void set_position(const rect_s &rect) override;
+		void set_upsize_info(const rectf_s &upsize) override;
+		void set_landmark_detection(const char *data_file_path) override;
 		bool get_face(struct rect_s &) override;
+		bool get_landmark(std::vector<pointf_s> &) override;
 };

--- a/src/face-tracker-manager.cpp
+++ b/src/face-tracker-manager.cpp
@@ -377,7 +377,7 @@ void face_tracker_manager::get_properties(obs_properties_t *pp)
 			OBS_PATH_FILE,
 			"Data Files (*.dat);;"
 			"All Files (*.*)",
-			NULL );
+			obs_get_module_data_path(obs_current_module()) );
 	obs_property_set_long_description(p, obs_module_text(
 				"You can get the shape_predictor_68_face_landmarks.dat file from: "
 				"http://dlib.net/files/shape_predictor_68_face_landmarks.dat.bz2" ));
@@ -396,4 +396,12 @@ void face_tracker_manager::get_defaults(obs_data_t *settings)
 	obs_data_set_default_double(settings, "scale", 2.0);
 	obs_data_set_default_bool(settings, "tracking_th_en", true);
 	obs_data_set_default_double(settings, "tracking_th_dB", -80.0);
+
+	if (char *f = obs_module_file("shape_predictor_5_face_landmarks.dat")) {
+		obs_data_set_default_string(settings, "landmark_detection_data", f);
+		bfree(f);
+	}
+	else {
+		blog(LOG_ERROR, "shape_predictor_5_face_landmarks.dat is not found in the data directory.");
+	}
 }

--- a/src/face-tracker-manager.hpp
+++ b/src/face-tracker-manager.hpp
@@ -71,6 +71,7 @@ class face_tracker_manager
 	private:
 		inline void retire_tracker(int ix);
 		inline bool is_low_confident(const tracker_inst_s &t, float th1);
+		void remove_duplicated_tracker();
 		void attenuate_tracker();
 		void copy_detector_to_tracker();
 		void stage_to_detector();

--- a/src/face-tracker-manager.hpp
+++ b/src/face-tracker-manager.hpp
@@ -9,6 +9,7 @@ class face_tracker_manager
 		struct tracker_rect_s {
 			rect_s rect;
 			rectf_s crop_rect;
+			std::vector<pointf_s> landmark;
 		};
 
 		struct tracker_inst_s
@@ -17,6 +18,7 @@ class face_tracker_manager
 			rect_s rect;
 			rectf_s crop_tracker; // crop corresponding to current processing image
 			rectf_s crop_rect; // crop corresponding to rect
+			std::vector<pointf_s> landmark;
 			float att;
 			float score_first;
 			enum tracker_state_e {
@@ -36,6 +38,7 @@ class face_tracker_manager
 		volatile bool reset_requested;
 		float tracking_threshold;
 		int detector_crop_l, detector_crop_r, detector_crop_t, detector_crop_b;
+		char *landmark_detection_data;
 
 	public: // realtime status
 		rectf_s crop_cur;

--- a/src/face-tracker-monitor.cpp
+++ b/src/face-tracker-monitor.cpp
@@ -12,6 +12,7 @@ struct face_tracker_monitor
 	char *filter_name;
 	bool notrack;
 	bool nosource;
+	bool landmark_only;
 
 	obs_weak_source_t *source_ref;
 	obs_weak_source_t *filter_ref;
@@ -67,6 +68,8 @@ static void ftmon_update(void *data, obs_data_t *settings)
 	s->notrack = obs_data_get_bool(settings, "notrack");
 
 	s->nosource = obs_data_get_bool(settings, "nosource");
+
+	s->landmark_only = obs_data_get_bool(settings, "landmark_only");
 }
 
 static obs_properties_t *ftmon_properties(void *data)
@@ -82,6 +85,8 @@ static obs_properties_t *ftmon_properties(void *data)
 	obs_properties_add_bool(props, "notrack", "Display original source");
 
 	obs_properties_add_bool(props, "nosource", "Overlay only");
+
+	obs_properties_add_bool(props, "landmark_only", "Display landmark information only");
 
 	return props;
 }
@@ -253,6 +258,9 @@ static void ftmon_video_render(void *data, gs_effect_t *)
 			obs_source_video_render(src);
 		}
 	}
+
+	if (s->landmark_only)
+		calldata_set_bool(&cd, "landmark_only", true);
 
 	proc_handler_call(ph, "render_info", &cd);
 

--- a/src/face-tracker-ptz.cpp
+++ b/src/face-tracker-ptz.cpp
@@ -357,7 +357,7 @@ static obs_properties_t *ftptz_properties(void *data)
 
 	{
 		obs_properties_t *pp = obs_properties_create();
-		obs_properties_add_float(pp, "track_z", obs_module_text("Zoom"), 0.1, 2.0, 0.1);
+		obs_properties_add_float(pp, "track_z", obs_module_text("Zoom"), 0.1, 2.0, 0.05);
 		obs_properties_add_float(pp, "track_x", obs_module_text("X"), -1.0, +1.0, 0.05);
 		obs_properties_add_float(pp, "track_y", obs_module_text("Y"), -1.0, +1.0, 0.05);
 		obs_properties_add_group(props, "track", obs_module_text("Tracking target location"), OBS_GROUP_NORMAL, pp);

--- a/src/face-tracker-ptz.cpp
+++ b/src/face-tracker-ptz.cpp
@@ -370,7 +370,7 @@ static obs_properties_t *ftptz_properties(void *data)
 		obs_property_float_set_suffix(p, " dB");
 		p = obs_properties_add_float(pp, "Kp_y_db", "Track Kp (Y)", -40.0, +80.0, 1.0);
 		obs_property_float_set_suffix(p, " dB");
-		p = obs_properties_add_float(pp, "Kp_z_db", "Track Kp (Z)", -40.0, +40.0, 1.0);
+		p = obs_properties_add_float(pp, "Kp_z_db", "Track Kp (Z)", -40.0, +60.0, 1.0);
 		obs_property_float_set_suffix(p, " dB");
 		obs_properties_add_float(pp, "Ki_x", "Track Ki (X)", 0.0, 5.0, 0.01);
 		obs_properties_add_float(pp, "Ki_y", "Track Ki (Y)", 0.0, 5.0, 0.01);

--- a/src/face-tracker.cpp
+++ b/src/face-tracker.cpp
@@ -232,7 +232,7 @@ static obs_properties_t *ftf_properties(void *data)
 
 	{
 		obs_properties_t *pp = obs_properties_create();
-		obs_properties_add_float(pp, "track_z", obs_module_text("Zoom"), 0.1, 2.0, 0.1);
+		obs_properties_add_float(pp, "track_z", obs_module_text("Zoom"), 0.1, 2.0, 0.05);
 		obs_properties_add_float(pp, "track_x", obs_module_text("X"), -1.0, +1.0, 0.05);
 		obs_properties_add_float(pp, "track_y", obs_module_text("Y"), -1.0, +1.0, 0.05);
 		obs_properties_add_float(pp, "scale_max", obs_module_text("Scale max"), 1.0, 20.0, 1.0);

--- a/src/face-tracker.cpp
+++ b/src/face-tracker.cpp
@@ -610,12 +610,25 @@ static inline void calculate_error(struct face_tracker_filter *s)
 	auto &tracker_rects = s->ftm->tracker_rects;
 	for (int i=0; i<tracker_rects.size(); i++) {
 		f3 r (tracker_rects[i].rect);
+
+		if (s->ftm->landmark_detection_data) {
+			pointf_s center = landmark_center(tracker_rects[i].landmark);
+			float area = landmark_area(tracker_rects[i].landmark);
+			if (area <= 0.0f)
+				continue;
+
+			r.v[0] = center.x;
+			r.v[1] = center.y;
+			r.v[2] = sqrtf(area * (float)(4.0f / M_PI));
+		}
+
 		r.v[0] -= get_width(tracker_rects[i].crop_rect) * s->track_x;
 		r.v[1] += get_height(tracker_rects[i].crop_rect) * s->track_y;
 		r.v[2] /= s->track_z;
 		r = ensure_range(r, s);
 		f3 w (tracker_rects[i].crop_rect);
 		float score = tracker_rects[i].rect.score;
+
 		f3 e = (r-w) * score;
 		debug_track("calculate_error: %d %f %f %f %f", i, e.v[0], e.v[1], e.v[2], score);
 		if (score>0.0f && !isnan(e)) {
@@ -743,9 +756,13 @@ static inline void draw_frame_texture(struct face_tracker_filter *s, bool debug_
 	}
 }
 
-static inline void draw_frame_info(struct face_tracker_filter *s, bool debug_notrack)
+static inline void draw_frame_info(struct face_tracker_filter *s, bool debug_notrack, bool landmark_only = false)
 {
 	const rectf_s &crop_cur = s->ftm->crop_cur;
+	bool draw_det = !landmark_only;
+	bool draw_trk = !landmark_only;
+	bool draw_lmk = true;
+	bool draw_ref = !landmark_only;
 
 	if (!debug_notrack) {
 		uint32_t width = s->width_with_aspect;
@@ -763,15 +780,21 @@ static inline void draw_frame_info(struct face_tracker_filter *s, bool debug_not
 
 	gs_effect_t *effect = obs_get_base_effect(OBS_EFFECT_SOLID);
 	while (gs_effect_loop(effect, "Solid")) {
-		gs_effect_set_color(gs_effect_get_param_by_name(effect, "color"), 0xFF0000FF);
-		for (int i=0; i<s->ftm->detect_rects.size(); i++)
-			draw_rect_upsize(s->ftm->detect_rects[i], s->ftm->upsize_l, s->ftm->upsize_r, s->ftm->upsize_t, s->ftm->upsize_b);
+		if (draw_det) {
+			gs_effect_set_color(gs_effect_get_param_by_name(effect, "color"), 0xFF0000FF);
+			for (int i=0; i<s->ftm->detect_rects.size(); i++)
+				draw_rect_upsize(s->ftm->detect_rects[i], s->ftm->upsize_l, s->ftm->upsize_r, s->ftm->upsize_t, s->ftm->upsize_b);
+		}
 
 		gs_effect_set_color(gs_effect_get_param_by_name(effect, "color"), 0xFF00FF00);
 		for (int i=0; i<s->ftm->tracker_rects.size(); i++) {
-			draw_rect_upsize(s->ftm->tracker_rects[i].rect);
+			const auto &tr = s->ftm->tracker_rects[i];
+			if (draw_trk)
+				draw_rect_upsize(tr.rect);
+			if (draw_lmk && tr.landmark.size())
+				draw_landmark(tr.landmark);
 		}
-		if (debug_notrack) {
+		if (debug_notrack && draw_ref) {
 			gs_effect_set_color(gs_effect_get_param_by_name(effect, "color"), 0xFFFFFF00); // amber
 			const rectf_s &r = s->ftm->crop_cur;
 			gs_render_start(false);
@@ -791,6 +814,14 @@ static inline void draw_frame_info(struct face_tracker_filter *s, bool debug_not
 			gs_vertex2f(rcx, rcy-srwhr2*s->track_z);
 			gs_vertex2f(rcx, rcy+srwhr2*s->track_z);
 			gs_render_stop(GS_LINES);
+
+			if (s->ftm->landmark_detection_data) {
+				gs_render_start(false);
+				float r = srwhr2 * s->track_z;
+				for (int i=0; i<=32; i++)
+					gs_vertex2f(rcx + r * sinf(M_PI * i / 8), rcy + r * cosf(M_PI * i / 8));
+				gs_render_stop(GS_LINESTRIP);
+			}
 		}
 	}
 
@@ -887,7 +918,10 @@ static void cb_render_info(void *data, calldata_t *cd)
 	bool debug_notrack = false;
 	calldata_get_bool(cd, "notrack", &debug_notrack);
 
-	draw_frame_info(s, debug_notrack);
+	bool landmark_only = false;
+	calldata_get_bool(cd, "landmark_only", &landmark_only);
+
+	draw_frame_info(s, debug_notrack, landmark_only);
 }
 
 static void cb_get_target_size(void *data, calldata_t *cd)

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -1,0 +1,137 @@
+#include <obs-module.h>
+#include "plugin-macros.generated.h"
+#include "helper.hpp"
+
+void draw_rect_upsize(rect_s r, float upsize_l, float upsize_r, float upsize_t, float upsize_b)
+{
+	if (r.x0>=r.x1 || r.y0>=r.y1)
+		return;
+	int w = r.x1-r.x0;
+	int h = r.y1-r.y0;
+	float dx0 = w * upsize_l;
+	float dx1 = w * upsize_r;
+	float dy0 = h * upsize_t;
+	float dy1 = h * upsize_b;
+
+	gs_render_start(false);
+
+	if (std::abs(dx0)>=0.5f || std::abs(dy1)>=0.5f || std::abs(dx1)>=0.5f || std::abs(dy0)>=0.5f) {
+		gs_vertex2f((float)r.x0, (float)r.y0); gs_vertex2f((float)r.x0, (float)r.y1);
+		gs_vertex2f((float)r.x0, (float)r.y1); gs_vertex2f((float)r.x1, (float)r.y1);
+		gs_vertex2f((float)r.x1, (float)r.y1); gs_vertex2f((float)r.x1, (float)r.y0);
+		gs_vertex2f((float)r.x1, (float)r.y0); gs_vertex2f((float)r.x0, (float)r.y0);
+	}
+	r.x0 -= (int)dx0;
+	r.x1 += (int)dx1;
+	r.y0 -= (int)dy0;
+	r.y1 += (int)dy1;
+	gs_vertex2f((float)r.x0, (float)r.y0); gs_vertex2f((float)r.x0, (float)r.y1);
+	gs_vertex2f((float)r.x0, (float)r.y1); gs_vertex2f((float)r.x1, (float)r.y1);
+	gs_vertex2f((float)r.x1, (float)r.y1); gs_vertex2f((float)r.x1, (float)r.y0);
+	gs_vertex2f((float)r.x1, (float)r.y0); gs_vertex2f((float)r.x0, (float)r.y0);
+
+	gs_render_stop(GS_LINES);
+}
+
+float landmark_area(const std::vector<pointf_s> &landmark)
+{
+	// TODO: implement area calculation for other models
+	// Maybe, use the area of the maximum convex polygon.
+
+	float ret = 0.0f;
+
+	const static int ii5[] = {
+		1, // center
+		// 0, 4, 2, 3, 1,
+		0, 1, 3, 2, 4,
+		0, -1 };
+
+	const static int ii68[] = {
+		30, // center
+		0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+		10, 11, 12, 13, 14, 15, 16,
+		26, 25, 24, 23, 22,
+		21, 20, 19, 18, 17,
+		0, -1 };
+
+	const int *ii =
+		landmark.size() == 68 ? ii68 :
+		landmark.size() == 5 ? ii5 :
+		NULL;
+
+	if (!ii) return 0.0f;
+
+	pointf_s c = landmark[ii[0]]; // center to minimize calculation errors
+	for (int i=1; ii[i+1] >= 0; i++) {
+		float x1 = landmark[ii[i]].x - c.x;
+		float y1 = landmark[ii[i]].y - c.y;
+		float x2 = landmark[ii[i+1]].x - c.x;
+		float y2 = landmark[ii[i+1]].y - c.y;
+		ret += (x2 * y1 - x1 * y2) * 0.5f;
+	}
+
+	return ret;
+}
+
+pointf_s landmark_center(const std::vector<pointf_s> &landmark)
+{
+	pointf_s ret = {0.0f, 0.0f};
+
+	for (size_t i=0; i<landmark.size(); i++) {
+		ret.x += landmark[i].x;
+		ret.y += landmark[i].y;
+	}
+
+	ret.x /= landmark.size();
+	ret.y /= landmark.size();
+
+	return ret;
+}
+
+void draw_landmark(const std::vector<pointf_s> &landmark)
+{
+	if (landmark.size() < 2)
+		return;
+
+	gs_render_start(false);
+
+	if (landmark.size()==5) {
+			gs_vertex2f(landmark[0].x, landmark[0].y);
+			gs_vertex2f(landmark[1].x, landmark[1].y);
+
+			gs_vertex2f(landmark[1].x, landmark[1].y);
+			gs_vertex2f(landmark[3].x, landmark[3].y);
+
+			gs_vertex2f(landmark[3].x, landmark[3].y);
+			gs_vertex2f(landmark[2].x, landmark[2].y);
+
+			gs_vertex2f(landmark[2].x, landmark[2].y);
+			gs_vertex2f(landmark[4].x, landmark[4].y);
+
+			gs_vertex2f(landmark[4].x, landmark[4].y);
+			gs_vertex2f(landmark[0].x, landmark[0].y);
+	}
+	else for (size_t i=0; i<landmark.size(); i++) {
+		// points should not be duplicated: 0, 16, 17, 21, 22, 26, 27, 30, 31, 35, 36, 41, 42, 47, 48, 59, 60, 57
+		if (i==42) {
+			gs_vertex2f(landmark[36].x, landmark[36].y);
+		}
+		else if (i==48) {
+			gs_vertex2f(landmark[42].x, landmark[42].y);
+		}
+		else if (i==60) {
+			gs_vertex2f(landmark[48].x, landmark[48].y);
+		}
+		else if (i==67) {
+			gs_vertex2f(landmark[60].x, landmark[60].y);
+		}
+		else if (i==0 || i==16 || i==17 || i==21 || i==22 || i==26 || i==27 || i==30 || i==31 || i==35 || i==36) {
+		}
+		else
+			gs_vertex2f(landmark[i].x, landmark[i].y);
+
+		gs_vertex2f(landmark[i].x, landmark[i].y);
+	}
+
+	gs_render_stop(GS_LINES);
+}

--- a/src/helper.hpp
+++ b/src/helper.hpp
@@ -1,6 +1,12 @@
 #pragma once
 #include <cmath>
 
+struct pointf_s
+{
+	float x;
+	float y;
+};
+
 struct rect_s
 {
 	int x0;

--- a/src/helper.hpp
+++ b/src/helper.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <cmath>
+#include <vector>
 
 struct pointf_s
 {
@@ -88,36 +89,10 @@ static inline rectf_s f3_to_rectf(const f3 &u, float w, float h)
 	return r;
 }
 
-static inline void draw_rect_upsize(rect_s r, float upsize_l=0.0f, float upsize_r=0.0f, float upsize_t=0.0f, float upsize_b=0.0f)
-{
-	if (r.x0>=r.x1 || r.y0>=r.y1)
-		return;
-	int w = r.x1-r.x0;
-	int h = r.y1-r.y0;
-	float dx0 = w * upsize_l;
-	float dx1 = w * upsize_r;
-	float dy0 = h * upsize_t;
-	float dy1 = h * upsize_b;
-
-	gs_render_start(false);
-
-	if (std::abs(dx0)>=0.5f || std::abs(dy1)>=0.5f || std::abs(dx1)>=0.5f || std::abs(dy0)>=0.5f) {
-		gs_vertex2f((float)r.x0, (float)r.y0); gs_vertex2f((float)r.x0, (float)r.y1);
-		gs_vertex2f((float)r.x0, (float)r.y1); gs_vertex2f((float)r.x1, (float)r.y1);
-		gs_vertex2f((float)r.x1, (float)r.y1); gs_vertex2f((float)r.x1, (float)r.y0);
-		gs_vertex2f((float)r.x1, (float)r.y0); gs_vertex2f((float)r.x0, (float)r.y0);
-	}
-	r.x0 -= (int)dx0;
-	r.x1 += (int)dx1;
-	r.y0 -= (int)dy0;
-	r.y1 += (int)dy1;
-	gs_vertex2f((float)r.x0, (float)r.y0); gs_vertex2f((float)r.x0, (float)r.y1);
-	gs_vertex2f((float)r.x0, (float)r.y1); gs_vertex2f((float)r.x1, (float)r.y1);
-	gs_vertex2f((float)r.x1, (float)r.y1); gs_vertex2f((float)r.x1, (float)r.y0);
-	gs_vertex2f((float)r.x1, (float)r.y0); gs_vertex2f((float)r.x0, (float)r.y0);
-
-	gs_render_stop(GS_LINES);
-}
+void draw_rect_upsize(rect_s r, float upsize_l=0.0f, float upsize_r=0.0f, float upsize_t=0.0f, float upsize_b=0.0f);
+void draw_landmark(const std::vector<pointf_s> &landmark);
+float landmark_area(const std::vector<pointf_s> &landmark);
+pointf_s landmark_center(const std::vector<pointf_s> &landmark);
 
 inline double from_dB(double x)
 {

--- a/src/texture-object.cpp
+++ b/src/texture-object.cpp
@@ -12,6 +12,7 @@ static uint32_t formats_found = 0;
 
 struct texture_object_private_s
 {
+	// TODO: allocate RGB image. According to the example for landmark detection, dlib accept RGB image. It should be more accurate.
 	dlib::array2d<unsigned char> dlib_img;
 	void *leak_test;
 };


### PR DESCRIPTION
### Description

Implement #55:
- Add face landmark detection.
- ~~Put textures on the face optionally. And not render the original texture optionally.~~
  Just not implemented yet.
- ~~If this is accurate and fast, it can replace correlation-tracker and will detect lost face earlier.~~
  The face landmark detection heavily relies on the rectangle of the detected face, hence correlation-tracker is still required.

### Result
Figure below shows zoom controls with conventional and new face tracker with the same video source (a camera shot  that I'm shitting on a chair and editing a source code.). The zoom target is adjusted to avoid difference caused by the landmark detection so that the zoom amount is similar. Other parameters between these face trackers are same. The conventional method shows more fluctuation.
![ft-compare](https://user-images.githubusercontent.com/780600/147747379-5a1ae3ab-56fa-4d2e-97d7-024b9e1eaa50.png)

### TODO items:
- [x] Upsize should be subtracted before running landmark detection.
- [x] Set default dataset.
- [x] Bundle 5-point dataset to packages
- [ ] Send RGB image to dlib (could be another PR)

### Checlist
<!-- If unsure, feel free to let them unchecked. -->
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
