### PR TITLE
ptz: Recall preset when face has lost

### DIFF
--- a/doc/properties-ptz.md
+++ b/doc/properties-ptz.md
@@ -109,6 +109,19 @@ The nonlinear band makes smooth connection from the dead band to the linear rang
 ### Attenuation time for lost face
 After the face is lost, integral term will be attenuated by this time. The dimension is time and the unit is s.
 
+## Face lost behavior
+
+Make an action if the face has been lost.
+
+### Timeout until action
+This is a timeout in seconds until the action will be triggered.
+
+### Recall memory
+Recall a memory (or preset) that is configured in your PTZ camera.
+Set `-1` to disable. The default is `-1`.
+
+Please be careful to use this option as the PTZ camera might change not only pan, tilt, and zoom but also other settings such as focus, and white balance shutter speed.
+
 ## Output
 This property group configure how to connect to the PTZ camera.
 

--- a/doc/properties-ptz.md
+++ b/doc/properties-ptz.md
@@ -113,7 +113,7 @@ After the face is lost, integral term will be attenuated by this time. The dimen
 
 Make an action if the face has been lost.
 
-### Timeout until action
+### Timeout until recalling memory
 This is a timeout in seconds until the action will be triggered.
 
 ### Recall memory
@@ -121,6 +121,10 @@ Recall a memory (or preset) that is configured in your PTZ camera.
 Set `-1` to disable. The default is `-1`.
 
 Please be careful to use this option as the PTZ camera might change not only pan, tilt, and zoom but also other settings such as focus, and white balance shutter speed.
+
+### Timeout until zoom-out
+Zoom-out if the face is lost and specified time has passed.
+Set `0` to disable.
 
 ## Output
 This property group configure how to connect to the PTZ camera.

--- a/src/dummy-backend.cpp
+++ b/src/dummy-backend.cpp
@@ -37,6 +37,11 @@ void dummy_backend::set_zoom_speed(int zoom)
 	prev_zoom = zoom;
 }
 
+void dummy_backend::recall_preset(int preset)
+{
+	blog(LOG_INFO, "recall_preset: %d", preset);
+}
+
 int dummy_backend::get_zoom()
 {
 	return 0;

--- a/src/dummy-backend.hpp
+++ b/src/dummy-backend.hpp
@@ -14,5 +14,6 @@ public:
 	void set_config(struct obs_data *data) override;
 	void set_pantilt_speed(int pan, int tilt) override;
 	void set_zoom_speed(int zoom) override;
+	void recall_preset(int preset) override;
 	int get_zoom() override;
 };

--- a/src/face-tracker-ptz.hpp
+++ b/src/face-tracker-ptz.hpp
@@ -30,9 +30,11 @@ struct face_tracker_ptz
 	int u[3];
 	int ptz_query[3];
 	uint64_t face_found_last_ns;
+	int face_lost_preset_sent;
 
-	int face_lost_timeout_ms;
+	int face_lost_preset_timeout_ms;
 	int face_lost_ptz_preset;
+	int face_lost_zoomout_timeout_ms;
 
 	bool debug_faces;
 	bool debug_notrack;

--- a/src/face-tracker-ptz.hpp
+++ b/src/face-tracker-ptz.hpp
@@ -29,6 +29,10 @@ struct face_tracker_ptz
 	float f_att_int;
 	int u[3];
 	int ptz_query[3];
+	uint64_t face_found_last_ns;
+
+	int face_lost_timeout_ms;
+	int face_lost_ptz_preset;
 
 	bool debug_faces;
 	bool debug_notrack;

--- a/src/libvisca-thread.cpp
+++ b/src/libvisca-thread.cpp
@@ -154,6 +154,12 @@ void libvisca_thread::thread_loop()
 			ptz_changed = true;
 		}
 
+		if (os_atomic_load_bool(&preset_changed)) {
+			os_sleep_ms(48);
+			VISCA_memory_recall(iface, camera, preset_rsvd);
+			os_sleep_ms(48);
+		}
+
 		uint16_t zoom_cur = 0;
 		if (VISCA_get_zoom_value(iface, camera, &zoom_cur) == VISCA_SUCCESS) {
 			os_atomic_set_long(&zoom_got, (long)zoom_cur);

--- a/src/libvisca-thread.hpp
+++ b/src/libvisca-thread.hpp
@@ -12,7 +12,9 @@ class libvisca_thread : public ptz_backend
 	struct _VISCA_camera *camera;
 	struct obs_data *data;
 	volatile bool data_changed;
+	volatile bool preset_changed;
 	volatile long pan_rsvd, tilt_rsvd, zoom_rsvd;
+	volatile int preset_rsvd;
 	volatile long zoom_got;
 
 	static void *thread_main(void *);
@@ -30,5 +32,9 @@ public:
 		os_atomic_set_long(&tilt_rsvd, tilt);
 	}
 	void set_zoom_speed(int zoom) override { os_atomic_set_long(&zoom_rsvd, zoom); }
+	void recall_preset(int preset) override {
+		preset_rsvd = preset;
+		os_atomic_set_bool(&preset_changed, true);
+	}
 	int get_zoom() override { return os_atomic_load_long(&zoom_got); }
 };

--- a/src/obsptz-backend.cpp
+++ b/src/obsptz-backend.cpp
@@ -105,6 +105,21 @@ void obsptz_backend::set_zoom_speed(int zoom)
 	prev_zoom = zoom;
 }
 
+void obsptz_backend::recall_preset(int preset)
+{
+	proc_handler_t *ph = get_ptz_ph();
+	if (!ph)
+		return;
+
+	CALLDATA_FIXED_DECL(cd, 128);
+	calldata_set_int(&cd, "device_id", device_id);
+	calldata_set_int(&cd, "preset_id", preset);
+	proc_handler_call(ph, "ptz_preset_recall", &cd);
+
+	uint64_t ns = os_gettime_ns();
+	available_ns = std::max(available_ns, ns) + (500*1000*1000);
+}
+
 int obsptz_backend::get_zoom()
 {
 	// TODO: implement

--- a/src/obsptz-backend.hpp
+++ b/src/obsptz-backend.hpp
@@ -21,5 +21,6 @@ public:
 	void tick() override;
 	void set_pantilt_speed(int pan, int tilt) override;
 	void set_zoom_speed(int zoom) override;
+	void recall_preset(int preset) override;
 	int get_zoom() override;
 };

--- a/src/ptz-backend.hpp
+++ b/src/ptz-backend.hpp
@@ -19,5 +19,6 @@ public:
 	virtual void tick() {}
 	virtual void set_pantilt_speed(int pan, int tilt) = 0;
 	virtual void set_zoom_speed(int zoom) = 0;
+	virtual void recall_preset(int preset) = 0;
 	virtual int get_zoom() = 0;
 };


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

When face has been lost, call preset on the PTZ camera.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

- [x] To avoid going to the preset at short lost of the face, timeout might be implemented.
- [ ] Test libvisca backend
- [x] Test obsptz backend

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.

Close #53
