### PR TITLE
src: Add config options to hide source types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,6 @@ option(WITH_DOCK "Enable dock" ON)
 option(ENABLE_DATAGEN "Enable generating data" OFF)
 
 set(CMAKE_PREFIX_PATH "${QTDIR}")
-set(CMAKE_AUTOMOC ON)
-set(CMAKE_AUTOUIC ON)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -47,6 +45,9 @@ set(DLIB_LINK_WITH_SQLITE3 OFF)
 set(DLIB_WEBP_SUPPORT OFF)
 set(DLIB_TEST_COMPILE_ALL_SOURCE_CPP OFF)
 add_subdirectory(dlib)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
 
 configure_file(
     src/plugin-macros.h.in

--- a/src/face-tracker-monitor.cpp
+++ b/src/face-tracker-monitor.cpp
@@ -279,16 +279,14 @@ static void ftmon_video_render(void *data, gs_effect_t *)
 }
 
 extern "C"
-void register_face_tracker_monitor()
+void register_face_tracker_monitor(bool hide_monitor)
 {
 	struct obs_source_info info = {};
 	info.id = "face_tracker_monitor";
 	info.type = OBS_SOURCE_TYPE_INPUT;
-	info.output_flags =
-#ifndef ENABLE_MONITOR_USER
-		OBS_SOURCE_CAP_DISABLED |
-#endif
-		OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW | OBS_SOURCE_DO_NOT_DUPLICATE;
+	info.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW | OBS_SOURCE_DO_NOT_DUPLICATE;
+	if (hide_monitor)
+		info.output_flags |= OBS_SOURCE_CAP_DISABLED;
 	info.get_name = ftmon_get_name;
 	info.create = ftmon_create;
 	info.destroy = ftmon_destroy;

--- a/src/face-tracker-ptz.cpp
+++ b/src/face-tracker-ptz.cpp
@@ -1089,12 +1089,14 @@ static void emit_state_changed(struct face_tracker_ptz *s)
 }
 
 extern "C"
-void register_face_tracker_ptz()
+void register_face_tracker_ptz(bool hide_ptz)
 {
 	struct obs_source_info info = {};
 	info.id = "face_tracker_ptz";
 	info.type = OBS_SOURCE_TYPE_FILTER;
 	info.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_ASYNC;
+	if (hide_ptz)
+		info.output_flags = OBS_SOURCE_CAP_DISABLED;
 	info.get_name = ftptz_get_name;
 	info.create = ftptz_create;
 	info.destroy = ftptz_destroy;

--- a/src/face-tracker.cpp
+++ b/src/face-tracker.cpp
@@ -1014,12 +1014,14 @@ static void emit_state_changed(struct face_tracker_filter *s)
 }
 
 extern "C"
-void register_face_tracker_filter()
+void register_face_tracker_filter(bool hide_filter, bool hide_source)
 {
 	struct obs_source_info info = {};
 	info.id = "face_tracker_filter";
 	info.type = OBS_SOURCE_TYPE_FILTER;
 	info.output_flags = OBS_SOURCE_VIDEO;
+	if (hide_filter)
+		info.output_flags |= OBS_SOURCE_CAP_DISABLED;
 	info.get_name = ftf_get_name;
 	info.create = ftf_create;
 	info.destroy = ftf_destroy;
@@ -1037,6 +1039,8 @@ void register_face_tracker_filter()
 	info.id = "face_tracker_source";
 	info.type = OBS_SOURCE_TYPE_INPUT;
 	info.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW | OBS_SOURCE_DO_NOT_DUPLICATE;
+	if (hide_source)
+		info.output_flags |= OBS_SOURCE_CAP_DISABLED;
 	info.create = fts_create;
 	info.update = fts_update;
 	info.get_properties = fts_properties;

--- a/src/module-main.c
+++ b/src/module-main.c
@@ -1,24 +1,49 @@
 #include <obs-module.h>
+#include <util/config-file.h>
+#include <obs-frontend-api.h>
 #include "plugin-macros.generated.h"
 #ifdef WITH_DOCK
 #include "../ui/face-tracker-dock.hpp"
 #endif // WITH_DOCK
 
+#define CONFIG_SECTION_NAME "face-tracker"
+
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE(PLUGIN_NAME, "en-US")
 
-void register_face_tracker_filter();
-void register_face_tracker_ptz();
-void register_face_tracker_monitor();
+void register_face_tracker_filter(bool hide_filter, bool hide_source);
+void register_face_tracker_ptz(bool hide_ptz);
+void register_face_tracker_monitor(bool hide_monitor);
 
 bool obs_module_load(void)
 {
 	blog(LOG_INFO, "registering face_tracker_filter_info (version %s)", PLUGIN_VERSION);
-	register_face_tracker_filter();
-	register_face_tracker_ptz();
-	register_face_tracker_monitor();
+
+	config_t *cfg = obs_frontend_get_global_config();
+
+	config_set_default_bool(cfg, CONFIG_SECTION_NAME, "ShowFilter", true);
+	config_set_default_bool(cfg, CONFIG_SECTION_NAME, "ShowSource", true);
+	config_set_default_bool(cfg, CONFIG_SECTION_NAME, "ShowPTZ", true);
+#ifdef ENABLE_MONITOR_USER
+	config_set_default_bool(cfg, CONFIG_SECTION_NAME, "ShowMonitor", true);
+#else
+	config_set_default_bool(cfg, CONFIG_SECTION_NAME, "ShowMonitor", false);
+#endif
+
+	bool show_filter = config_get_bool(cfg, CONFIG_SECTION_NAME, "ShowFilter");
+	bool show_source = config_get_bool(cfg, CONFIG_SECTION_NAME, "ShowSource");
+	bool show_ptz = config_get_bool(cfg, CONFIG_SECTION_NAME, "ShowPTZ");
+	bool show_monitor = config_get_bool(cfg, CONFIG_SECTION_NAME, "ShowMonitor");
+
+	register_face_tracker_filter(!show_filter, !show_source);
+	register_face_tracker_ptz(!show_ptz);
+	register_face_tracker_monitor(!show_monitor);
+
 #ifdef WITH_DOCK
-	ft_docks_init();
+	config_set_default_bool(cfg, CONFIG_SECTION_NAME, "LoadDock", true);
+	bool load_dock = config_get_bool(cfg, CONFIG_SECTION_NAME, "LoadDock");
+	if (load_dock)
+		ft_docks_init();
 #endif // WITH_DOCK
 	return true;
 }


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

This PR adds global-config options to hide source and filter types.

Having too many source types is annoying when adding a new source.

Also slightly modify cmake to avoid some warnings.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
