### PR TITLE
ptz: Fix wrong minimum setting for face_lost_zoomout_timeout

### DIFF
--- a/src/face-tracker-ptz.cpp
+++ b/src/face-tracker-ptz.cpp
@@ -418,7 +418,7 @@ static obs_properties_t *ftptz_properties(void *data)
 		obs_property_float_set_suffix(p, " s");
 		obs_properties_add_int(pp, "face_lost_ptz_preset", "Recall memory (-1 for disable)", -1, 15, 1);
 		obs_properties_add_group(props, "facelost", obs_module_text("Face lost behavior"), OBS_GROUP_NORMAL, pp);
-		p = obs_properties_add_float(pp, "face_lost_zoomout_timeout", "Timeout until zoom-out", 0.1, 60.0, 0.1);
+		p = obs_properties_add_float(pp, "face_lost_zoomout_timeout", "Timeout until zoom-out", 0.0, 60.0, 0.1);
 		obs_property_float_set_suffix(p, " s");
 	}
 


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

The setting `face_lost_zoomout_timeout` should take 0.0 so that the option will be disabled.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

Tested on Fedora 39.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.

Fix #155.
