### PR TITLE
ptz: Move backend-specific code to each backend

### DIFF
--- a/src/dummy-backend.cpp
+++ b/src/dummy-backend.cpp
@@ -42,7 +42,7 @@ void dummy_backend::recall_preset(int preset)
 	blog(LOG_INFO, "recall_preset: %d", preset);
 }
 
-int dummy_backend::get_zoom()
+float dummy_backend::get_zoom()
 {
-	return 0;
+	return 1.0f;
 }

--- a/src/dummy-backend.hpp
+++ b/src/dummy-backend.hpp
@@ -15,5 +15,5 @@ public:
 	void set_pantilt_speed(int pan, int tilt) override;
 	void set_zoom_speed(int zoom) override;
 	void recall_preset(int preset) override;
-	int get_zoom() override;
+	float get_zoom() override;
 };

--- a/src/face-tracker-ptz.hpp
+++ b/src/face-tracker-ptz.hpp
@@ -33,7 +33,8 @@ struct face_tracker_ptz
 	f3 filter_lpf;
 	float f_att_int;
 	int u[3];
-	int ptz_query[3];
+	float u_linear[3];
+	float ptz_query[3];
 	uint64_t face_found_last_ns;
 	int face_lost_preset_sent;
 

--- a/src/face-tracker-ptz.hpp
+++ b/src/face-tracker-ptz.hpp
@@ -53,7 +53,6 @@ struct face_tracker_ptz
 	char *debug_data_control_last;
 
 	char *ptz_type;
-	int ptz_max_x, ptz_max_y, ptz_max_z;
 
 	bool is_paused;
 	obs_hotkey_pair_id hotkey_pause;

--- a/src/libvisca-thread.cpp
+++ b/src/libvisca-thread.cpp
@@ -240,3 +240,20 @@ void libvisca_thread::set_config(struct obs_data *data_)
 
 	pthread_mutex_unlock(&mutex);
 }
+
+float libvisca_thread::raw2zoomfactor(int zoom)
+{
+	// TODO: configurable
+	return expf((float)zoom * (logf(20.0f) / 16384.f));
+}
+
+bool libvisca_thread::ptz_type_modified(obs_properties_t *pp, obs_data_t *settings)
+{
+	(void)settings;
+	if (obs_properties_get(pp, "ptz.visca-over-tcp.address"))
+		return false;
+
+	obs_properties_add_text(pp, "ptz.visca-over-tcp.address", obs_module_text("IP address"), OBS_TEXT_DEFAULT);
+	obs_properties_add_int(pp, "ptz.visca-over-tcp.port", obs_module_text("Port"), 1, 65535, 1);
+	return true;
+}

--- a/src/libvisca-thread.hpp
+++ b/src/libvisca-thread.hpp
@@ -19,6 +19,7 @@ class libvisca_thread : public ptz_backend
 	static void *thread_main(void *);
 	void thread_connect();
 	void thread_loop();
+	float raw2zoomfactor(int);
 
 public:
 	libvisca_thread();
@@ -35,5 +36,15 @@ public:
 		preset_rsvd = preset;
 		os_atomic_set_bool(&preset_changed, true);
 	}
-	int get_zoom() override { return os_atomic_load_long(&zoom_got); }
+	float get_zoom() override { return raw2zoomfactor(os_atomic_load_long(&zoom_got)); }
+
+	inline static bool check_data(obs_data_t *data)
+	{
+		if (!obs_data_get_string(data, "address"))
+			return false;
+		if (obs_data_get_int(data, "port") <= 0)
+			return false;
+		return true;
+	}
+	static bool ptz_type_modified(obs_properties_t *group_output, obs_data_t *settings);
 };

--- a/src/obsptz-backend.cpp
+++ b/src/obsptz-backend.cpp
@@ -120,8 +120,17 @@ void obsptz_backend::recall_preset(int preset)
 	available_ns = std::max(available_ns, ns) + (500*1000*1000);
 }
 
-int obsptz_backend::get_zoom()
+float obsptz_backend::get_zoom()
 {
 	// TODO: implement
-	return 0;
+	return 1.0f;
+}
+
+bool obsptz_backend::ptz_type_modified(obs_properties_t *pp, obs_data_t *)
+{
+	if (obs_properties_get(pp, "ptz.obsptz.device_id"))
+		return false;
+
+	obs_properties_add_int(pp, "ptz.obsptz.device_id", obs_module_text("Device ID"), 0, 99, 1);
+	return true;
 }

--- a/src/obsptz-backend.hpp
+++ b/src/obsptz-backend.hpp
@@ -5,6 +5,7 @@ class obsptz_backend : public ptz_backend
 {
 	uint64_t available_ns = 0;
 	int device_id = -1;
+	int ptz_max_x = 0, ptz_max_y = 0, ptz_max_z = 0;
 	proc_handler_t *ptz_ph = NULL;
 	proc_handler_t *get_ptz_ph();
 	int prev_pan = 0;

--- a/src/obsptz-backend.hpp
+++ b/src/obsptz-backend.hpp
@@ -22,5 +22,7 @@ public:
 	void set_pantilt_speed(int pan, int tilt) override;
 	void set_zoom_speed(int zoom) override;
 	void recall_preset(int preset) override;
-	int get_zoom() override;
+	float get_zoom() override;
+
+	static bool ptz_type_modified(obs_properties_t *group_output, obs_data_t *settings);
 };

--- a/src/ptz-backend.hpp
+++ b/src/ptz-backend.hpp
@@ -20,5 +20,15 @@ public:
 	virtual void set_pantilt_speed(int pan, int tilt) = 0;
 	virtual void set_zoom_speed(int zoom) = 0;
 	virtual void recall_preset(int preset) = 0;
-	virtual int get_zoom() = 0;
+	virtual float get_zoom() = 0;
+
+	virtual void set_pantiltzoom_speed(float pan, float tilt, float zoom) { (void)pan; (void)tilt; (void)zoom; }
+
+	inline static bool check_data(obs_data_t *) { return true; }
+	inline static bool ptz_type_modified(obs_properties_t *group_output, obs_data_t *settings)
+	{
+		(void)group_output;
+		(void)settings;
+		return false;
+	}
 };


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

The device-specific implementations for settings and properties were written in `src/face-tracker-ptz.cpp`. This makes difficult to maintain or add more device types.

This PR moves the code to each source file of the backend device.

The modification is separated from #161.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [ ] The commit is reviewed by yourself.
- [ ] The code is tested.
- [ ] Document is up to date or not necessary to be changed.
- [ ] The commit is compatible with repository's license.
