### PR TITLE
ci/macos: Fix library dependency

### DIFF
--- a/ci/macos/change-rpath.sh
+++ b/ci/macos/change-rpath.sh
@@ -36,6 +36,12 @@ function copy_local_dylib
 		fi
 		install_name_tool -change "$dylib" "@loader_path/../$libdir/$b" $1
 	done
+
+	otool -L $1 > $t
+	if grep -v '\(:\|^\s@\|^\s/System/Library\|^\s/usr/lib\)' < $t >&2 ; then
+		echo "Error: $1: Detected bad dependency" >&2
+		exit 1
+	fi
 }
 
 function change_obs27_libs

--- a/ci/macos/change-rpath.sh
+++ b/ci/macos/change-rpath.sh
@@ -23,7 +23,7 @@ function copy_local_dylib
 	local dylib
 	t=$(mktemp)
 	otool -L $1 > $t
-	awk '/^	\/usr\/local\/(opt|Cellar)\/.*\.dylib/{print $1}' $t |
+	awk '/^	(\/usr\/local\/opt|\/usr\/local\/Cellar|\/opt\/homebrew)\/.*\.dylib/{print $1}' $t |
 	while read -r dylib; do
 		echo "Changing dependency $1 -> $dylib"
 		local b=$(basename $dylib)


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

The issue was reported in #179 that the plugin is not loaded on Apple Silicon macOS.

This PR will fix the resolution of dependencies.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

The first commit will test the issue and should automatically fail the workflow... It failed as expected.
The second commit actually fixed the issue.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [ ] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.

Resolve #179.
